### PR TITLE
Create Login and Sign-up components

### DIFF
--- a/fujiji-client/jest.config.js
+++ b/fujiji-client/jest.config.js
@@ -12,8 +12,18 @@ const customJestConfig = {
   // setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
   // if using TypeScript with a baseUrl set to the root directory then you need the below for alias' to work
   moduleDirectories: ['node_modules', '<rootDir>/'],
-  testEnvironment: 'jest-environment-jsdom',
+  testEnvironment: 'jsdom',
   setupFilesAfterEnv: ['<rootDir>/__test__/jest.setup.js'],
+
+  transform: {
+    '^.+\\.[jt]sx?$': 'babel-jest',
+  },
+  transformIgnorePatterns: ['/node_modules/', '\\.pnp\\.[^\\/]+$'],
+
+  clearMocks: true,
+  collectCoverage: true,
+  coverageDirectory: 'coverage',
+  coverageReporters: ['text', 'html'],
 };
 
 // createJestConfig is exported this way to ensure that next/jest can load the Next.js config which is async

--- a/fujiji-client/package.json
+++ b/fujiji-client/package.json
@@ -38,6 +38,7 @@
     "@storybook/testing-library": "0.0.8",
     "@testing-library/jest-dom": "^5.16.2",
     "@testing-library/react": "^12.1.2",
+    "babel-jest": "^27.5.1",
     "babel-loader": "^8.2.3",
     "eslint": "^8.8.0",
     "eslint-config-airbnb": "^19.0.4",

--- a/fujiji-client/src/components/SignIn/SignIn.jsx
+++ b/fujiji-client/src/components/SignIn/SignIn.jsx
@@ -1,0 +1,169 @@
+import { useState } from 'react';
+import PropTypes from 'prop-types';
+import {
+  Box,
+  Button,
+  Link,
+  IconButton,
+  Input,
+  InputGroup,
+  InputLeftElement,
+  InputRightElement,
+  Stack,
+  FormControl,
+  FormHelperText,
+  Flex,
+  Text,
+} from '@chakra-ui/react';
+import {
+  AtSignIcon, LockIcon, ViewIcon, ViewOffIcon,
+} from '@chakra-ui/icons';
+
+function validateEmail(email) {
+  return email.match(
+    // eslint-disable-next-line no-useless-escape
+    /^(([^<>()[\]\\.,;:\s@\"]+(\.[^<>()[\]\\.,;:\s@\"]+)*)|(\".+\"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/,
+  );
+}
+
+export default function SignIn({ isSignUp = false }) {
+  const [emailInput, setEmailInput] = useState('');
+  const [passwordInput, setPasswordInput] = useState('');
+
+  const [showPassword, setShowPassword] = useState(false);
+
+  const [emailErrorMessage, setEmailError] = useState('');
+  const [passwordErrorMessage, setPasswordError] = useState('');
+
+  const submitButtonText = isSignUp ? 'Sign Up' : 'Login';
+  const helperText = isSignUp
+    ? 'Already have an account?'
+    : "Don't have an account?";
+  const helperLinkText = isSignUp ? 'Login' : 'Sign Up';
+  const helperLink = isSignUp ? '#' : '#';
+
+  const handleShowClick = () => {
+    setShowPassword(!showPassword);
+  };
+
+  const handlePasswordChange = (event) => {
+    setPasswordInput(event.target.value);
+  };
+
+  const handleEmailChange = (event) => {
+    setEmailInput(event.target.value);
+  };
+
+  const handleOnSubmit = () => {
+    // unset error messages
+    setEmailError('');
+    setPasswordError('');
+
+    if (!emailInput) {
+      setEmailError("Email can't be empty");
+    }
+
+    if (emailInput && !validateEmail(emailInput)) {
+      setEmailError('Invalid email');
+    }
+
+    if (!passwordInput) {
+      setPasswordError("Password can't be empty");
+    }
+
+    if (passwordInput && passwordInput.length < 8) {
+      setPasswordError('Password need at least 8 characters');
+    }
+    /**
+     * TODO: Handle email and password. And send appropriate request to backend
+     */
+  };
+
+  return (
+    <Flex>
+      <Box minW={{ base: '90%', md: '400px' }} borderRadius="lg">
+        <Flex
+          flexDirection="column"
+          justifyContent="center"
+          alignItems="center"
+          mb="1rem"
+        >
+          <Text fontSize="6xl">Fujiji</Text>
+        </Flex>
+        <Stack spacing={4} p="1rem">
+          <FormControl>
+            <InputGroup>
+              <InputLeftElement pointerEvents="none">
+                <AtSignIcon color="gray.400" />
+              </InputLeftElement>
+              <Input
+                aria-label="email"
+                isInvalid={emailErrorMessage}
+                type="email"
+                placeholder="email address"
+                onChange={handleEmailChange}
+              />
+            </InputGroup>
+            {emailErrorMessage && (
+              <FormHelperText>{emailErrorMessage}</FormHelperText>
+            )}
+          </FormControl>
+          <FormControl>
+            <InputGroup>
+              <InputLeftElement pointerEvents="none">
+                <LockIcon color="gray.400" />
+              </InputLeftElement>
+              <Input
+                aria-label="password"
+                isInvalid={passwordErrorMessage}
+                type={showPassword ? 'text' : 'password'}
+                placeholder="password"
+                onChange={handlePasswordChange}
+              />
+              <InputRightElement>
+                <IconButton
+                  size="sm"
+                  color="gray.500"
+                  bg="none"
+                  aria-label={showPassword ? 'Hide password' : 'Show password'}
+                  icon={showPassword ? <ViewOffIcon /> : <ViewIcon />}
+                  onClick={handleShowClick}
+                />
+              </InputRightElement>
+            </InputGroup>
+            {passwordErrorMessage && (
+              <FormHelperText>{passwordErrorMessage}</FormHelperText>
+            )}
+          </FormControl>
+          <Button
+            borderRadius="md"
+            type="submit"
+            variant="solid"
+            colorScheme="teal"
+            width="full"
+            onClick={handleOnSubmit}
+          >
+            {submitButtonText}
+          </Button>
+        </Stack>
+        <Flex
+          flexDirection="column"
+          justifyContent="center"
+          alignItems="center"
+        >
+          <Box>
+            {helperText}
+            {' '}
+            <Link color="teal.500" href={helperLink}>
+              {helperLinkText}
+            </Link>
+          </Box>
+        </Flex>
+      </Box>
+    </Flex>
+  );
+}
+
+SignIn.propTypes = {
+  isSignUp: PropTypes.bool,
+};

--- a/fujiji-client/src/components/SignIn/SignIn.spec.jsx
+++ b/fujiji-client/src/components/SignIn/SignIn.spec.jsx
@@ -1,0 +1,54 @@
+import { render, fireEvent } from '@testing-library/react';
+
+import SignIn from './SignIn';
+
+describe('TestComponent', () => {
+  it('should render login components properly', () => {
+    const { getByText } = render(<SignIn />);
+    expect(getByText("Don't have an account?")).toBeInTheDocument();
+    expect(getByText('Login')).toBeInTheDocument();
+  });
+
+  it('should render sign-up components properly', () => {
+    const { getByText } = render(<SignIn isSignUp />);
+    expect(getByText('Already have an account?')).toBeInTheDocument();
+    expect(getByText('Sign Up')).toBeInTheDocument();
+  });
+
+  it('should render empty error messages when submitting an empty form', () => {
+    const { getByText } = render(<SignIn />);
+
+    fireEvent.click(getByText('Login'), { bubbles: true });
+
+    expect(getByText("Email can't be empty")).toBeInTheDocument();
+    expect(getByText("Password can't be empty")).toBeInTheDocument();
+  });
+
+  it('should render invalid error messages when submitting invalid email and password', () => {
+    const { getByText, getByLabelText } = render(<SignIn />);
+
+    fireEvent.change(getByLabelText('email'), {
+      target: { value: 'invalid email' },
+    });
+    fireEvent.change(getByLabelText('password'), {
+      target: { value: '1234567' },
+    });
+
+    fireEvent.click(getByText('Login'), { bubbles: true });
+
+    expect(getByText('Invalid email')).toBeInTheDocument();
+    expect(
+      getByText('Password need at least 8 characters'),
+    ).toBeInTheDocument();
+  });
+
+  it('should render show and hide password icon properly', () => {
+    const { getByLabelText } = render(<SignIn />);
+
+    fireEvent.click(getByLabelText('Show password'), { bubbles: true });
+    expect(getByLabelText('Hide password')).toBeInTheDocument();
+
+    fireEvent.click(getByLabelText('Hide password'), { bubbles: true });
+    expect(getByLabelText('Show password')).toBeInTheDocument();
+  });
+});

--- a/fujiji-client/src/components/SignIn/SignIn.stories.jsx
+++ b/fujiji-client/src/components/SignIn/SignIn.stories.jsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import SignIn from './SignIn';
+
+export default {
+  title: 'SignIn',
+  component: SignIn,
+};
+
+function Template({ ...args }) {
+  return <SignIn {...args} />;
+}
+
+export const Default = Template.bind({});
+
+Default.args = {
+  isSignUp: false,
+};
+
+// export const Primary;

--- a/fujiji-client/src/components/index.js
+++ b/fujiji-client/src/components/index.js
@@ -1,3 +1,4 @@
 // eslint-disable import/prefer-default-export
 export { default as Navigation } from './Navigation/Navigation';
 export { default as AdListing } from './AdListing/AdListing';
+export { default as SignIn } from './SignIn/SignIn';


### PR DESCRIPTION
**Description:**
- Create login and sign-up components that contains input for email and password
- The `isSignUp` prop will determine whether this component is for Login or Sign-up
- Added tests and Storybook story
- Closes #41 

**Demo:**

https://user-images.githubusercontent.com/36686154/154328975-d158e62f-0152-4cd9-8f61-8e021948f20a.mov


