### PR TITLE
feat/#51: Build a Form to create a listing

### DIFF
--- a/fujiji-client/.eslintrc
+++ b/fujiji-client/.eslintrc
@@ -1,4 +1,8 @@
 {
+  "env": {
+    "browser": true,
+    "node": true
+  },
   "extends": [
     // "next/core-web-vitals",
     "airbnb",

--- a/fujiji-client/jest.config.js
+++ b/fujiji-client/jest.config.js
@@ -12,11 +12,11 @@ const customJestConfig = {
   // setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
   // if using TypeScript with a baseUrl set to the root directory then you need the below for alias' to work
   moduleDirectories: ['node_modules', '<rootDir>/'],
-  testEnvironment: 'jsdom',
+  testEnvironment: 'jest-environment-jsdom',
   setupFilesAfterEnv: ['<rootDir>/__test__/jest.setup.js'],
 
   transform: {
-    '^.+\\.[jt]sx?$': 'babel-jest',
+    '^.+\\.(js|jsx|ts|tsx)$': ['babel-jest', { presets: ['next/babel'] }],
   },
   transformIgnorePatterns: ['/node_modules/', '\\.pnp\\.[^\\/]+$'],
 

--- a/fujiji-client/src/components/AlertContainer/AlertContainer.jsx
+++ b/fujiji-client/src/components/AlertContainer/AlertContainer.jsx
@@ -1,0 +1,79 @@
+import PropTypes from 'prop-types';
+
+import {
+  AlertDialog,
+  AlertDialogBody,
+  AlertDialogCloseButton,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogContent,
+  AlertDialogOverlay,
+  Button,
+} from '@chakra-ui/react';
+
+/**
+ *
+/**
+ * @param {string} headerText
+ * @param {string} contentText
+ * @param {string} confirmButtonText
+ * @param {string} confirmButtonColor
+ * @param {string} cancelButtonText
+ * @param {bool} isOpen whether the the Alert dialog should show or not
+ * @param {ref} cancelRef ref to the Component that trigger this alert
+ * @param {func} onClose callback function to close the Alert dialog
+ * @param {func} onConfirm callback function when confirming the changes
+ */
+export default function AlertContainer({
+  headerText,
+  contentText,
+  confirmButtonText,
+  confirmButtonColor = 'red',
+  cancelButtonText,
+  isOpen = false,
+  cancelRef,
+  onClose,
+  onConfirm,
+}) {
+  return (
+    <AlertDialog
+      motionPreset="slideInBottom"
+      leastDestructiveRef={cancelRef}
+      onClose={onClose}
+      isOpen={isOpen}
+      isCentered
+    >
+      <AlertDialogOverlay />
+
+      <AlertDialogContent mx="3">
+        <AlertDialogHeader>{headerText}</AlertDialogHeader>
+        <AlertDialogCloseButton />
+        <AlertDialogBody>{contentText}</AlertDialogBody>
+        <AlertDialogFooter>
+          <Button ref={cancelRef} onClick={onClose}>
+            {cancelButtonText}
+          </Button>
+          <Button colorScheme={confirmButtonColor} ml={3} onClick={onConfirm}>
+            {confirmButtonText}
+          </Button>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}
+
+AlertContainer.propTypes = {
+  headerText: PropTypes.string,
+  contentText: PropTypes.string,
+  confirmButtonText: PropTypes.string,
+  confirmButtonColor: PropTypes.string,
+  cancelButtonText: PropTypes.string,
+  isOpen: PropTypes.bool,
+  cancelRef: PropTypes.oneOfType([
+    PropTypes.func,
+    // eslint-disable-next-line react/forbid-prop-types
+    PropTypes.shape({ current: PropTypes.any }),
+  ]),
+  onClose: PropTypes.func,
+  onConfirm: PropTypes.func,
+};

--- a/fujiji-client/src/components/AlertContainer/AlertContainer.stories.jsx
+++ b/fujiji-client/src/components/AlertContainer/AlertContainer.stories.jsx
@@ -1,0 +1,22 @@
+import { React } from 'react';
+import AlertContainer from './AlertContainer';
+
+export default {
+  title: 'AlertContainer',
+  component: AlertContainer,
+};
+
+function Template({ ...args }) {
+  return <AlertContainer {...args} />;
+}
+
+export const Default = Template.bind({});
+
+Default.args = {
+  headerText: 'Header',
+  contentText: 'Content',
+  confirmButtonText: 'Confirm',
+  confirmButtonColor: 'red',
+  cancelButtonText: 'Cancel',
+  isOpen: false,
+};

--- a/fujiji-client/src/components/ListingForm/ListingForm.jsx
+++ b/fujiji-client/src/components/ListingForm/ListingForm.jsx
@@ -1,0 +1,374 @@
+import PropTypes from 'prop-types';
+import { useState, useRef } from 'react';
+import {
+  AspectRatio,
+  Box,
+  Button,
+  Flex,
+  FormControl,
+  FormLabel,
+  FormHelperText,
+  Icon,
+  Image,
+  Input,
+  InputGroup,
+  InputLeftElement,
+  Select,
+  Stack,
+  Text,
+  Textarea,
+  useDisclosure,
+} from '@chakra-ui/react';
+import {
+  AddIcon,
+  AttachmentIcon,
+  DeleteIcon,
+  EditIcon,
+} from '@chakra-ui/icons';
+import { BsCurrencyDollar } from 'react-icons/bs';
+import AlertContainer from '../AlertContainer/AlertContainer';
+import { provinces, furnitureCategories } from '../../utils/fujijiConfig';
+
+const inputMarginTop = 4;
+
+const allowedFileExtension = ['.png', '.jpg', '.jpeg'];
+const allowedFileType = ['image/png', 'image/jpg', 'image/jpeg'];
+
+function renderDeleteButton(isUpdate, onClick) {
+  return (
+    <Button
+      aria-label="delete-button"
+      ml="4"
+      leftIcon={<DeleteIcon fontSize="sm" />}
+      colorScheme={isUpdate ? 'red' : 'gray'}
+      fontWeight="semibold"
+      variant="outline"
+      onClick={onClick}
+    >
+      {isUpdate ? 'Delete' : 'Discard'}
+    </Button>
+  );
+}
+
+function validateImage(fileImage) {
+  const fileExtension = fileImage.name.split('.').pop();
+  const fileType = fileImage.type;
+  return (
+    allowedFileExtension.includes(`.${fileExtension}`)
+    && allowedFileType.includes(fileType)
+  );
+}
+
+/**
+ * @param {string} title title of the listing
+ * @param {string} description description of the listing
+ * @param {string} condition condition of the furniture
+ * @param {string} city city where the seller sell this listing
+ * @param {string} province province CODE where the seller sell this listing
+ * @param {string} imageUrl URL to image that need to be rendered
+ * @param {bool} isUpdate flag to toggle between POST and UPDATE form
+ * @param {func} onSubmit callback function that will be executed when the form is submitted with valid input
+ * @param {func} onDelete callback function that will be executed when the form is discarded (during POST) and deleted (during UPDATE)
+ */
+export default function ListingForm({
+  title,
+  description,
+  condition = 'Used',
+  city,
+  province = 'MB',
+  imageUrl,
+  price,
+  category = 'Other',
+  isUpdate = false,
+  onSubmit,
+  onDelete,
+}) {
+  const [listingTitle, setListingTitle] = useState(title);
+  const [listingDescription, setListingDescription] = useState(description);
+  const [listingCondition, setListingCondition] = useState(condition);
+  const [listingCity, setListingCity] = useState(city);
+  const [listingProvince, setListingProvince] = useState(province);
+  const [listingImageUrl, setListingImageUrl] = useState(imageUrl);
+  const [listingPrice, setListingPrice] = useState(price);
+  const [listingCategory, setListingCategory] = useState(category);
+
+  const [uploadErrorMessage, setUploadErrorMessage] = useState('');
+  const [titleErrorMessage, setTitleErrorMessage] = useState('');
+  const [cityErrorMessage, setCityErrorMessage] = useState('');
+  const [priceErrorMessage, setPriceErrorMessage] = useState('');
+
+  const [uploadedImage, setUploadedImage] = useState(undefined);
+
+  const inputRef = useRef();
+  const { isOpen, onOpen, onClose } = useDisclosure();
+  const cancelRef = useRef();
+
+  const alertDialogProps = {
+    headerText: isUpdate ? 'Delete Listing' : 'Discard Changes',
+    contentText: isUpdate
+      ? "Are you sure? You can't undo this action afterwards."
+      : 'Are you sure? All unsaved changes will be lost.',
+    confirmButtonText: isUpdate ? 'Delete' : 'Discard',
+    confirmButtonColor: 'red',
+    cancelButtonText: 'Cancel',
+    isOpen,
+    onClose,
+    cancelRef,
+    onDelete,
+  };
+
+  const uploadButtonText = uploadedImage
+    ? uploadedImage.name
+    : 'Attach new image';
+
+  const handleOnSubmit = () => {
+    setTitleErrorMessage('');
+    setCityErrorMessage('');
+    setUploadErrorMessage('');
+    setPriceErrorMessage('');
+
+    const isImageExist = !isUpdate ? uploadedImage : imageUrl;
+
+    const isValid = listingTitle && isImageExist && listingCity && listingPrice;
+
+    if (!listingTitle) {
+      setTitleErrorMessage("Title can't be empty");
+    }
+
+    if (!listingCity) {
+      setCityErrorMessage("City can't be empty");
+    }
+
+    if (!isImageExist) {
+      setUploadErrorMessage('Listing must have an image');
+    }
+
+    if (!listingPrice) {
+      setPriceErrorMessage('Price is invalid (valid ex: 5000 or 49.99)');
+    }
+
+    if (isValid) {
+      onSubmit();
+    }
+  };
+
+  const handleOnImageUpload = (e) => {
+    setUploadErrorMessage('');
+    const uploadedFile = e.target.files[0] || undefined;
+    if (!uploadedFile || !validateImage(uploadedFile)) {
+      setUploadErrorMessage('Allowed files: .png, .jpg, .jpeg');
+    } else {
+      setUploadedImage(uploadedFile);
+      setListingImageUrl(URL.createObjectURL(uploadedFile));
+    }
+    e.target.value = null; // reset onChange value
+  };
+
+  return (
+    <Box p={[3, 6]} d="flex" maxW="600px" borderWidth="1px" borderRadius="lg">
+      <FormControl>
+        <Box>
+          <FormLabel htmlFor="listingTitle" id="listing-title-label">
+            Title
+          </FormLabel>
+          <Input
+            aria-label="listing-title"
+            id="listing-title"
+            type="text"
+            placeholder="Title"
+            onChange={(e) => setListingTitle(e.target.value)}
+            value={listingTitle}
+            isInvalid={titleErrorMessage}
+          />
+          {titleErrorMessage && (
+            <FormHelperText>{titleErrorMessage}</FormHelperText>
+          )}
+        </Box>
+        <Stack direction="row" mt={inputMarginTop} align="stretch">
+          <Box flex="1">
+            <FormLabel htmlFor="listingCdondition" id="listing-condition-label">
+              Condition
+            </FormLabel>
+            <Select
+              aria-label="listing-condition"
+              id="listing-condition-selector"
+              onChange={(e) => {
+                setListingCondition(e.target.value);
+              }}
+              value={listingCondition}
+            >
+              <option key="brand-new">Brand New</option>
+              <option key="used">Used</option>
+              <option key="refurbished">Refurbished</option>
+            </Select>
+          </Box>
+          <Box flex="1">
+            <FormLabel htmlFor="listingCategory" id="listing-category-label">
+              Category
+            </FormLabel>
+            <Select
+              aria-label="listing-category"
+              id="listing-category-selector"
+              onChange={(e) => {
+                setListingCategory(e.target.value);
+              }}
+              value={listingCategory}
+            >
+              {furnitureCategories.map((c) => (
+                <option key={c}>{c}</option>
+              ))}
+            </Select>
+          </Box>
+        </Stack>
+
+        <Box mt={inputMarginTop}>
+          <FormLabel
+            htmlFor="listingDescription"
+            id="listing-description-label"
+          >
+            Description
+          </FormLabel>
+          <Textarea
+            aria-label="listing-description"
+            id="listing-description"
+            placeholder="Tell buyers abour your listing!"
+            resize="vertical"
+            onChange={(e) => setListingDescription(e.target.value)}
+            value={listingDescription}
+          />
+        </Box>
+
+        <Stack direction="row" mt={inputMarginTop}>
+          <Box>
+            <FormLabel htmlFor="listingCity" id="listing-city-label">
+              City
+            </FormLabel>
+            <Input
+              aria-label="listing-city"
+              id="listing-city"
+              type="text"
+              onChange={(e) => setListingCity(e.target.value)}
+              value={listingCity}
+              isInvalid={cityErrorMessage}
+            />
+            {cityErrorMessage && (
+              <FormHelperText>{cityErrorMessage}</FormHelperText>
+            )}
+          </Box>
+          <Box>
+            <FormLabel htmlFor="listingProvince" id="listing-province-label">
+              Province
+            </FormLabel>
+            <Select
+              aria-label="listing-province"
+              id="listing-province-selector"
+              onChange={(e) => {
+                setListingProvince(e.target.value);
+              }}
+              value={listingProvince}
+            >
+              {provinces.map((p) => (
+                <option key={p.code}>{p.code}</option>
+              ))}
+            </Select>
+          </Box>
+        </Stack>
+
+        <Box mt={inputMarginTop}>
+          <FormLabel htmlFor="listingImage" id="listing-image-label">
+            Upload Image
+          </FormLabel>
+          {listingImageUrl && (
+            <AspectRatio ratio={4 / 3} mb="4">
+              <Image
+                aria-label="listing-image"
+                id="listing-image"
+                alt="Current uploaded listing image"
+                src={listingImageUrl}
+                borderWidth="1px"
+                borderRadius="lg"
+                shadow="xs"
+              />
+            </AspectRatio>
+          )}
+          <InputGroup>
+            <Button
+              onClick={() => inputRef.current.click()}
+              aria-label="upload-button"
+              leftIcon={<AttachmentIcon />}
+              w="100%"
+              fontWeight="normal"
+              borderWidth={uploadErrorMessage ? '2px' : '0px'}
+              borderColor={uploadErrorMessage ? 'red' : ''}
+            >
+              <Text isTruncated>{uploadButtonText}</Text>
+            </Button>
+            <input
+              id="image-upload-input"
+              type="file"
+              ref={inputRef}
+              hidden
+              onChange={handleOnImageUpload}
+            />
+          </InputGroup>
+          {uploadErrorMessage && (
+            <FormHelperText>{uploadErrorMessage}</FormHelperText>
+          )}
+        </Box>
+
+        <Box mt={inputMarginTop} maxW="230px">
+          <FormLabel htmlFor="listingPrice" id="listing-price-label">
+            Price
+          </FormLabel>
+          <InputGroup>
+            <InputLeftElement pointerEvents="none">
+              <Icon as={BsCurrencyDollar} color="gray.400" />
+            </InputLeftElement>
+            <Input
+              aria-label="listing-price"
+              id="listing-price"
+              type="number"
+              onChange={(e) => setListingPrice(e.target.value)}
+              value={listingPrice}
+              isInvalid={priceErrorMessage}
+              step="0.01"
+            />
+          </InputGroup>
+          {priceErrorMessage && (
+            <FormHelperText>{priceErrorMessage}</FormHelperText>
+          )}
+        </Box>
+
+        <Flex mt="10">
+          <Button
+            aria-label="submit-button"
+            leftIcon={
+              isUpdate ? <EditIcon fontSize="sm" /> : <AddIcon fontSize="sm" />
+            }
+            colorScheme="teal"
+            fontWeight="semibold"
+            onClick={handleOnSubmit}
+          >
+            {isUpdate ? 'Update' : 'Post'}
+          </Button>
+          {renderDeleteButton(isUpdate, onOpen)}
+          <AlertContainer {...alertDialogProps} />
+        </Flex>
+      </FormControl>
+    </Box>
+  );
+}
+
+ListingForm.propTypes = {
+  title: PropTypes.string,
+  description: PropTypes.string,
+  condition: PropTypes.string,
+  city: PropTypes.string,
+  province: PropTypes.string,
+  imageUrl: PropTypes.string,
+  price: PropTypes.number,
+  category: PropTypes.string,
+  isUpdate: PropTypes.bool,
+  onSubmit: PropTypes.func,
+  onDelete: PropTypes.func,
+};

--- a/fujiji-client/src/components/ListingForm/ListingForm.spec.jsx
+++ b/fujiji-client/src/components/ListingForm/ListingForm.spec.jsx
@@ -1,0 +1,195 @@
+import { render, fireEvent } from '@testing-library/react';
+
+import ListingForm from './ListingForm';
+
+const mockInvalidFile = {
+  name: 'test.txt',
+  type: 'random/type',
+};
+
+const mockValidFile = {
+  name: 'test.png',
+  type: 'image/png',
+};
+
+const mockUpdateProps = {
+  title: 'mockTitle',
+  description: 'mockDescription',
+  condition: 'Refurbished',
+  city: 'mockCity',
+  province: 'BC',
+  imageUrl: 'mockUrl',
+  price: 99,
+  category: 'Other',
+  isUpdate: true,
+};
+
+const mockPostProps = {
+  title: 'mockTitle',
+  description: 'mockDescription',
+  condition: 'Refurbished',
+  city: 'mockCity',
+  province: 'BC',
+  price: 99,
+  category: 'Other',
+  isUpdate: false,
+};
+
+describe('ListingForm', () => {
+  it('should render with empty props (post form)', () => {
+    const { getByText } = render(<ListingForm />);
+    // isUpdate is false by default. e.g., render component for POST
+    expect(getByText('Post')).toBeInTheDocument();
+    expect(getByText('Discard')).toBeInTheDocument();
+    // condition is "Used" by default
+    expect(getByText('Used').selected).toBeTruthy();
+    expect(getByText('Brand New').selected).toBeFalsy();
+    expect(getByText('Refurbished').selected).toBeFalsy();
+    // province is "MB" by default
+    expect(getByText('MB').selected).toBeTruthy();
+    expect(getByText('Other').selected).toBeTruthy();
+  });
+
+  it('should render update form', () => {
+    const { getByText, getByDisplayValue } = render(
+      <ListingForm {...mockUpdateProps} />,
+    );
+
+    expect(getByDisplayValue(mockUpdateProps.title)).toBeInTheDocument();
+    expect(getByDisplayValue(mockUpdateProps.description)).toBeInTheDocument();
+    expect(getByDisplayValue(mockUpdateProps.city)).toBeInTheDocument();
+    expect(getByText('Update')).toBeInTheDocument();
+    expect(getByText('Delete')).toBeInTheDocument();
+    expect(getByText(mockUpdateProps.condition).selected).toBeTruthy();
+    expect(getByText(mockUpdateProps.province).selected).toBeTruthy();
+  });
+
+  it('should give errors when submitting incomplete form', () => {
+    const { getByText } = render(<ListingForm />);
+
+    fireEvent.click(getByText('Post'), { bubbles: true });
+
+    expect(getByText("Title can't be empty")).toBeInTheDocument();
+    expect(getByText("City can't be empty")).toBeInTheDocument();
+    expect(getByText('Listing must have an image')).toBeInTheDocument();
+    expect(
+      getByText('Price is invalid (valid ex: 5000 or 49.99)'),
+    ).toBeInTheDocument();
+  });
+
+  it('should give errors when uploading incorrect file format', () => {
+    const { getByText } = render(<ListingForm {...mockUpdateProps} />);
+
+    const fileInput = document.querySelector('#image-upload-input');
+
+    fireEvent.change(fileInput, {
+      target: {
+        files: [
+          new File(['(⌐□_□)'], mockInvalidFile.name, {
+            type: mockInvalidFile.type,
+          }),
+        ],
+      },
+    });
+
+    expect(getByText('Allowed files: .png, .jpg, .jpeg')).toBeInTheDocument();
+  });
+
+  it('should not give errors when submitting a valid file format', () => {
+    global.URL.createObjectURL = jest.fn(() => 'url');
+    const { queryByText, getByLabelText } = render(
+      <ListingForm {...mockUpdateProps} />,
+    );
+
+    const fileInput = document.querySelector('#image-upload-input');
+
+    fireEvent.change(fileInput, {
+      target: {
+        files: [
+          new File(['(⌐□_□)'], mockValidFile.name, {
+            type: mockValidFile.type,
+          }),
+        ],
+      },
+    });
+
+    expect(queryByText('Allowed files: .png, .jpg, .jpeg')).toBeFalsy();
+    expect(getByLabelText('listing-image')).toBeInTheDocument();
+  });
+
+  it('should submit the form if all fields are valid', () => {
+    const mockOnSubmit = jest.fn();
+
+    const { getByText, getByDisplayValue } = render(
+      <ListingForm {...mockPostProps} onSubmit={mockOnSubmit} />,
+    );
+
+    const fileInput = document.querySelector('#image-upload-input');
+
+    fireEvent.change(fileInput, {
+      target: {
+        files: [
+          new File(['(⌐□_□)'], mockValidFile.name, {
+            type: mockValidFile.type,
+          }),
+        ],
+      },
+    });
+
+    fireEvent.click(getByText('Post'), { bubbles: true });
+
+    expect(getByDisplayValue(mockPostProps.title)).toBeInTheDocument();
+    expect(getByDisplayValue(mockPostProps.description)).toBeInTheDocument();
+    expect(getByDisplayValue(mockPostProps.city)).toBeInTheDocument();
+    expect(getByText('Post')).toBeInTheDocument();
+    expect(getByText('Discard')).toBeInTheDocument();
+    expect(getByText(mockPostProps.condition).selected).toBeTruthy();
+    expect(getByText(mockPostProps.province).selected).toBeTruthy();
+    expect(mockOnSubmit).toHaveBeenCalledTimes(1);
+  });
+
+  it('should change the input value properly', () => {
+    const mockOnSubmit = jest.fn();
+
+    const { getByText, getByLabelText, getByDisplayValue } = render(
+      <ListingForm {...mockPostProps} onSubmit={mockOnSubmit} />,
+    );
+
+    fireEvent.change(getByLabelText('listing-title'), {
+      target: { value: 'different title' },
+    });
+    fireEvent.change(getByLabelText('listing-condition'), {
+      target: { value: 'Brand New' },
+    });
+    fireEvent.change(getByLabelText('listing-description'), {
+      target: { value: 'different description' },
+    });
+    fireEvent.change(getByLabelText('listing-city'), {
+      target: { value: 'Toronto' },
+    });
+    fireEvent.change(getByLabelText('listing-province'), {
+      target: { value: 'ON' },
+    });
+    fireEvent.change(getByLabelText('listing-category'), {
+      target: { value: 'Chair' },
+    });
+    fireEvent.change(getByLabelText('listing-price'), {
+      target: { value: 2345 },
+    });
+
+    expect(getByDisplayValue('different title')).toBeInTheDocument();
+    expect(getByDisplayValue('different description')).toBeInTheDocument();
+    expect(getByDisplayValue('Toronto')).toBeInTheDocument();
+
+    expect(getByText('Brand New').selected).toBeTruthy();
+    expect(getByText('Refurbished').selected).toBeFalsy();
+
+    expect(getByText('ON').selected).toBeTruthy();
+    expect(getByText('BC').selected).toBeFalsy();
+
+    expect(getByText('Chair').selected).toBeTruthy();
+    expect(getByText('Other').selected).toBeFalsy();
+
+    expect(getByDisplayValue('2345')).toBeInTheDocument();
+  });
+});

--- a/fujiji-client/src/components/ListingForm/ListingForm.stories.jsx
+++ b/fujiji-client/src/components/ListingForm/ListingForm.stories.jsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import ListingForm from './ListingForm';
+
+export default {
+  title: 'ListingForm',
+  component: ListingForm,
+  argTypes: {
+    condition: {
+      options: ['Brand New', 'Used', 'Refurbished'],
+      control: { type: 'select' },
+    },
+    postingDate: {
+      control: { type: 'text' },
+      defaultValue: '2022-02-21',
+    },
+  },
+};
+
+function Template({ ...args }) {
+  return <ListingForm {...args} />;
+}
+
+export const Default = Template.bind({});
+
+Default.args = {
+  isUpdate: false,
+};
+
+export const Post = Template.bind({});
+
+Post.args = {
+  title: 'New Listing',
+  description: 'test description',
+  condition: 'Brand New',
+  city: 'Winnipeg',
+  province: 'MB',
+  price: 150.02,
+  category: 'Chair',
+  isUpdate: false,
+};
+
+export const Update = Template.bind({});
+
+Update.args = {
+  title: 'Plain old chair',
+  description: 'test description',
+  condition: 'Brand New',
+  city: 'Winnipeg',
+  province: 'MB',
+  imageUrl: 'https://source.unsplash.com/ueJ2oJeEK-U/',
+  price: 1900.0,
+  category: 'Chair',
+  isUpdate: true,
+};

--- a/fujiji-client/src/components/SignIn/SignIn.jsx
+++ b/fujiji-client/src/components/SignIn/SignIn.jsx
@@ -18,13 +18,7 @@ import {
 import {
   AtSignIcon, LockIcon, ViewIcon, ViewOffIcon,
 } from '@chakra-ui/icons';
-
-function validateEmail(email) {
-  return email.match(
-    // eslint-disable-next-line no-useless-escape
-    /^(([^<>()[\]\\.,;:\s@\"]+(\.[^<>()[\]\\.,;:\s@\"]+)*)|(\".+\"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/,
-  );
-}
+import { validateEmail } from '../../utils/validate';
 
 export default function SignIn({ isSignUp = false }) {
   const [emailInput, setEmailInput] = useState('');

--- a/fujiji-client/src/components/index.js
+++ b/fujiji-client/src/components/index.js
@@ -4,4 +4,5 @@ export { default as AdListingCard } from './AdListingCard/AdListingCard';
 export { default as ConditionBadge } from './ConditionBadge/ConditionBadge';
 export { default as Listing } from './Listing/Listing';
 export { default as SignIn } from './SignIn/SignIn';
+export { default as ListingForm } from './ListingForm/ListingForm';
 export { default as PageLayout } from './PageLayout/PageLayout';

--- a/fujiji-client/src/utils/fujijiConfig.js
+++ b/fujiji-client/src/utils/fujijiConfig.js
@@ -1,0 +1,55 @@
+export const furnitureCategories = [
+  'Bed',
+  'Cabinet',
+  'Chair',
+  'Desk',
+  'Sofa',
+  'Table',
+  'Other',
+];
+
+export const provinces = [
+  {
+    name: 'Alberta',
+    code: 'AB',
+  },
+  {
+    name: 'British Columbia',
+    code: 'BC',
+  },
+
+  {
+    name: 'Manitoba',
+    code: 'MB',
+  },
+  {
+    name: 'Newfoundland and Labrador',
+    code: 'NL',
+  },
+  {
+    name: 'New Brunswick',
+    code: 'NB',
+  },
+  {
+    name: 'Nova Scotia',
+    code: 'NS',
+  },
+  {
+    name: 'Ontario',
+    code: 'ON',
+  },
+  {
+    name: 'Prince Edward Island',
+    code: 'PE',
+  },
+  {
+    name: 'Quebec',
+    code: 'QC',
+  },
+  {
+    name: 'Saskatchewan',
+    code: 'SK',
+  },
+];
+
+export const conditions = ['New', 'Used', 'Refurbished'];

--- a/fujiji-client/src/utils/validate.js
+++ b/fujiji-client/src/utils/validate.js
@@ -1,0 +1,11 @@
+// this eslint disable should be removed when we are adding more functions into validate.js
+
+// eslint-disable-next-line import/prefer-default-export
+export function validateEmail(email) {
+  if (!email) return false;
+
+  return email.match(
+    // eslint-disable-next-line no-useless-escape
+    /^(([^<>()[\]\\.,;:\s@\"]+(\.[^<>()[\]\\.,;:\s@\"]+)*)|(\".+\"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/,
+  );
+}


### PR DESCRIPTION
# Description

Created a Form that able to `CREATE`, `UPDATE`, and `DELETE` listing.

This form can be re-used for editing the listing as a seller.

There will be an alert dialog if user want to _Delete_ a listing or _Discard_ their changes

`isUpdate` prop is used to determine if we want to render a `CREATE` or `UPDATE` form

`onSubmit` prop is a callback that we can pass functions for `POST` or `UPDATE` request. The same applies for `onDelete`

Fixed Jest error where it does not properly map uncovered lines.

Closes #51 

# Demo

![Screen Shot 2022-02-23 at 2 53 30 PM](https://user-images.githubusercontent.com/36686154/155407584-2c3d7989-ea0d-45cc-87c2-5ba3a68f8126.png)

![Screen Shot 2022-02-23 at 2 53 22 PM](https://user-images.githubusercontent.com/36686154/155407588-a8029e4c-daf1-4739-b2ef-be6580034630.png)


![Screen Shot 2022-02-22 at 9 16 33 PM](https://user-images.githubusercontent.com/36686154/155256265-81561cbc-9673-496e-af3f-6300ba1f7f0b.png)

https://user-images.githubusercontent.com/36686154/155255729-3c30a0a4-2ad1-4098-9f18-09469751e121.mov


