### PR TITLE
Feat/#64 create endpoints to filter ad listings

### DIFF
--- a/fujiji-server/__test__/controllers/auth.test.js
+++ b/fujiji-server/__test__/controllers/auth.test.js
@@ -5,6 +5,7 @@ const { mockUser, seedTestDB, tearDownDB } = require('../dbSetup');
 describe('Test /auth endpoints', () => {
   describe('POST /signup', () => {
     beforeAll(async () => {
+      await tearDownDB();
       await seedTestDB();
     });
 

--- a/fujiji-server/__test__/controllers/listing.test.js
+++ b/fujiji-server/__test__/controllers/listing.test.js
@@ -5,6 +5,7 @@ const { seedTestDB, tearDownDB } = require('../dbSetup');
 describe('Test /listing endpoints', () => {
   describe('GET /listing', () => {
     beforeEach(async () => {
+      await tearDownDB();
       await seedTestDB();
     });
 
@@ -17,6 +18,13 @@ describe('Test /listing endpoints', () => {
         .get('/listing')
         .query({ city: 'Winnipeg' });
       expect(res.statusCode).toEqual(200);
+    });
+
+    it('nonexistent city returns expected error', async () => {
+      const res = await request(app)
+        .get('/listing')
+        .query({ city: 'None' });
+      expect(res.statusCode).toEqual(404);
     });
 
     it('successfully get all listings by existing province', async () => {
@@ -55,7 +63,7 @@ describe('Test /listing endpoints', () => {
     it('successfully get all listings by existing province and condition', async () => {
       const res = await request(app)
         .get('/listing')
-        .query({ provinceCode: 'MB', category: 'used' });
+        .query({ provinceCode: 'MB', condition: 'used' });
       expect(res.statusCode).toEqual(200);
     });
 

--- a/fujiji-server/__test__/controllers/listing.test.js
+++ b/fujiji-server/__test__/controllers/listing.test.js
@@ -30,5 +30,61 @@ describe('Test /listing endpoints', () => {
       const res = await request(app).get('/listing');
       expect(res.statusCode).toEqual(400);
     });
+
+    it('successfully get all listings by existing city and category', async () => {
+      const res = await request(app)
+        .get('/listing')
+        .query({ city: 'Winnipeg', category: 'Other' });
+      expect(res.statusCode).toEqual(200);
+    });
+
+    it('successfully get all listings by existing province and category', async () => {
+      const res = await request(app)
+        .get('/listing')
+        .query({ provinceCode: 'MB', category: 'Other' });
+      expect(res.statusCode).toEqual(200);
+    });
+
+    it('successfully get all listings by existing city and condition', async () => {
+      const res = await request(app)
+        .get('/listing')
+        .query({ city: 'Winnipeg', condition: 'used' });
+      expect(res.statusCode).toEqual(200);
+    });
+
+    it('successfully get all listings by existing province and condition', async () => {
+      const res = await request(app)
+        .get('/listing')
+        .query({ provinceCode: 'MB', category: 'used' });
+      expect(res.statusCode).toEqual(200);
+    });
+
+    it('successfully get all listings by existing city and valid priceRange', async () => {
+      const res = await request(app)
+        .get('/listing')
+        .query({ city: 'Winnipeg', priceRange: [0, 100] });
+      expect(res.statusCode).toEqual(200);
+    });
+
+    it('successfully get all listings by existing province and valid priceRange', async () => {
+      const res = await request(app)
+        .get('/listing')
+        .query({ provinceCode: 'MB', priceRange: [0, 100] });
+      expect(res.statusCode).toEqual(200);
+    });
+
+    it('invalid price range with existing city returns expected error', async () => {
+      const res = await request(app)
+        .get('/listing')
+        .query({ city: 'Winnipeg', priceRange: [100] });
+      expect(res.statusCode).toEqual(400);
+    });
+
+    it('invalid price range with existing province returns expected error', async () => {
+      const res = await request(app)
+        .get('/listing')
+        .query({ provinceCode: 'MB', priceRange: [100] });
+      expect(res.statusCode).toEqual(400);
+    });
   });
 });

--- a/fujiji-server/src/app.js
+++ b/fujiji-server/src/app.js
@@ -38,11 +38,9 @@ app.get('/appstatus', async (req, res) => {
   };
   let [allUser] = '';
   let [allListing] = '';
-  let [allToken] = '';
   try {
     [allUser] = await sequelize.query('SELECT * FROM fujiji_user');
     [allListing] = await sequelize.query('SELECT * FROM fujiji_listing');
-    [allToken] = await sequelize.query('SELECT * FROM fujiji_token');
   } catch (err) {
     console.log(err);
   }
@@ -51,7 +49,6 @@ app.get('/appstatus', async (req, res) => {
     response,
     allUser,
     allListing,
-    allToken,
   });
 });
 

--- a/fujiji-server/src/controllers/listing.js
+++ b/fujiji-server/src/controllers/listing.js
@@ -1,17 +1,103 @@
 const { getAllListingsByCity } = require('../repositories/listing');
 const { getAllListingsByProvince } = require('../repositories/listing');
+const { getAllListingsByCityCategory } = require('../repositories/listing');
+const { getAllListingsByProvinceCategory } = require('../repositories/listing');
+const { getAllListingsByCityCondition } = require('../repositories/listing');
+const { getAllListingsByProvinceCondition } = require('../repositories/listing');
+const { getAllListingsByCityPriceRange } = require('../repositories/listing');
+const { getAllListingsByProvincePriceRange } = require('../repositories/listing');
 const APIError = require('../errors/api');
 const ListingNotFoundError = require('../errors/listing/listingNotFound');
 const ListingLocationUndefinedError = require('../errors/listing/listingLocationUndefined');
+const ListingInvalidPriceRangeError = require('../errors/listing/listingInvalidPriceRange');
+
+function validatePriceRange(priceRange) {
+  try {
+    if (priceRange.length == 2) {
+      if (priceRange[0] <= priceRange[1]) {
+        return true;
+      }
+    }
+    return false;
+  } catch (err) {
+    return err;
+  }
+}
+
+async function getListingsByCity(req) {
+  try {
+    let listings = {};
+
+    if (req.query.category) {
+      listings = await getAllListingsByCityCategory(
+        req.query.city,
+        req.query.category,
+      );
+    } else if (req.query.condition) {
+      listings = await getAllListingsByCityCondition(
+        req.query.city,
+        req.query.condition,
+      );
+    } else if (req.query.priceRange) {
+      if (!validatePriceRange(req.query.priceRange)) {
+        return new ListingInvalidPriceRangeError();
+      }
+      listings = await getAllListingsByCityPriceRange(
+        req.query.city,
+        req.query.priceRange[0],
+        req.query.priceRange[1],
+      );
+    } else {
+      listings = await getAllListingsByCity(req.query.city);
+    }
+
+    return listings;
+  } catch (err) {
+    return err;
+  }
+}
+
+async function getListingsByProvince(req) {
+  try {
+    let listings = {};
+
+    if (req.query.category) {
+      listings = await getAllListingsByProvinceCategory(
+        req.query.provinceCode,
+        req.query.category,
+      );
+    } else if (req.query.condition) {
+      listings = await getAllListingsByProvinceCondition(
+        req.query.provinceCode,
+        req.query.condition,
+      );
+    } else if (req.query.priceRange) {
+      if (!validatePriceRange(req.query.priceRange)) {
+        return new ListingInvalidPriceRangeError();
+      }
+      listings = await getAllListingsByProvincePriceRange(
+        req.query.provinceCode,
+        req.query.priceRange[0],
+        req.query.priceRange[1],
+      );
+    } else {
+      listings = await getAllListingsByProvince(req.query.provinceCode);
+    }
+
+    return listings;
+  } catch (err) {
+    return err;
+  }
+}
 
 async function getAllListings(req, res, next) {
   try {
     let listings = {};
 
     if (req.query.city) {
-      listings = await getAllListingsByCity(req.query.city);
+      listings = await getListingsByCity(req);
     } else if (req.query.provinceCode) {
-      listings = await getAllListingsByProvince(req.query.provinceCode);
+      listings = await getListingsByProvince(req);
     } else {
       next(new ListingLocationUndefinedError());
       return;
@@ -19,6 +105,11 @@ async function getAllListings(req, res, next) {
 
     if (listings.length === 0) {
       next(new ListingNotFoundError());
+      return;
+    }
+
+    if (listings instanceof APIError) {
+      next(listings);
       return;
     }
     res.status(200).json({ listings });

--- a/fujiji-server/src/errors/listing/listingInvalidPriceRange.js
+++ b/fujiji-server/src/errors/listing/listingInvalidPriceRange.js
@@ -1,0 +1,9 @@
+const APIError = require('../api');
+
+class ListingInvalidPriceRangeError extends APIError {
+  constructor(message) {
+    super(message || 'Listing\'s price range needs 2 values with the first one being less than the second one.', 400);
+  }
+}
+
+module.exports = ListingInvalidPriceRangeError;

--- a/fujiji-server/src/repositories/listing.js
+++ b/fujiji-server/src/repositories/listing.js
@@ -1,4 +1,5 @@
 const { Sequelize } = require('sequelize');
+const { logDebug } = require('../utils/logging');
 const sequelize = require('./db');
 
 async function getAllListingsByCity(city) {
@@ -10,6 +11,7 @@ async function getAllListingsByCity(city) {
         type: Sequelize.SELECT,
       },
     );
+    logDebug('DEBUG-listingsByCity', listingsByCity);
     return listingsByCity;
   } catch (err) {
     return err;
@@ -25,8 +27,7 @@ async function getAllListingsByCityCategory(city, category) {
         type: Sequelize.SELECT,
       },
     );
-    console.log('DEBUG-listingsByCityCategory');
-    console.log(listingsByCityCategory);
+    logDebug('DEBUG-listingsByCityCategory', listingsByCityCategory);
     return listingsByCityCategory;
   } catch (err) {
     return err;
@@ -42,8 +43,7 @@ async function getAllListingsByCityCondition(city, condition) {
         type: Sequelize.SELECT,
       },
     );
-    console.log('DEBUG-listingsByCityCondition');
-    console.log(listingsByCityCondition);
+    logDebug('DEBUG-listingsByCityCondition', listingsByCityCondition);
     return listingsByCityCondition;
   } catch (err) {
     return err;
@@ -59,8 +59,7 @@ async function getAllListingsByCityPriceRange(city, startPrice, endPrice) {
         type: Sequelize.SELECT,
       },
     );
-    console.log('DEBUG-listingsByCityPriceRange');
-    console.log(listingsByCityPriceRange);
+    logDebug('DEBUG-listingsByCityPriceRange', listingsByCityPriceRange);
     return listingsByCityPriceRange;
   } catch (err) {
     return err;
@@ -76,6 +75,7 @@ async function getAllListingsByProvince(provinceCode) {
         type: Sequelize.SELECT,
       },
     );
+    logDebug('DEBUG-listingsByProvince', listingsByProvince);
     return listingsByProvince;
   } catch (err) {
     return err;
@@ -91,8 +91,7 @@ async function getAllListingsByProvinceCategory(provinceCode, category) {
         type: Sequelize.SELECT,
       },
     );
-    console.log('DEBUG-listingsByProvinceCategory');
-    console.log(listingsByProvinceCategory);
+    logDebug('DEBUG-listingsByProvinceCategory', listingsByProvinceCategory);
     return listingsByProvinceCategory;
   } catch (err) {
     return err;
@@ -108,8 +107,7 @@ async function getAllListingsByProvinceCondition(provinceCode, condition) {
         type: Sequelize.SELECT,
       },
     );
-    console.log('DEBUG-listingsByProvinceConditon');
-    console.log(listingsByProvinceCondition);
+    logDebug('DEBUG-listingsByProvinceConditon', listingsByProvinceCondition);
     return listingsByProvinceCondition;
   } catch (err) {
     return err;
@@ -125,8 +123,7 @@ async function getAllListingsByProvincePriceRange(provinceCode, startPrice, endP
         type: Sequelize.SELECT,
       },
     );
-    console.log('DEBUG-listingsByProvincePriceRange');
-    console.log(listingsByProvincePriceRange);
+    logDebug('DEBUG-listingsByProvincePriceRange', listingsByProvincePriceRange);
     return listingsByProvincePriceRange;
   } catch (err) {
     return err;

--- a/fujiji-server/src/repositories/listing.js
+++ b/fujiji-server/src/repositories/listing.js
@@ -16,6 +16,57 @@ async function getAllListingsByCity(city) {
   }
 }
 
+async function getAllListingsByCityCategory(city, category) {
+  try {
+    const [listingsByCityCategory] = await sequelize.query(
+      'SELECT * FROM fujiji_listing WHERE city = ? AND category = ?',
+      {
+        replacements: [city, category],
+        type: Sequelize.SELECT,
+      },
+    );
+    console.log('DEBUG-listingsByCityCategory');
+    console.log(listingsByCityCategory);
+    return listingsByCityCategory;
+  } catch (err) {
+    return err;
+  }
+}
+
+async function getAllListingsByCityCondition(city, condition) {
+  try {
+    const [listingsByCityCondition] = await sequelize.query(
+      'SELECT * FROM fujiji_listing WHERE city = ? AND condition = ?',
+      {
+        replacements: [city, condition],
+        type: Sequelize.SELECT,
+      },
+    );
+    console.log('DEBUG-listingsByCityCondition');
+    console.log(listingsByCityCondition);
+    return listingsByCityCondition;
+  } catch (err) {
+    return err;
+  }
+}
+
+async function getAllListingsByCityPriceRange(city, startPrice, endPrice) {
+  try {
+    const [listingsByCityPriceRange] = await sequelize.query(
+      'SELECT * FROM fujiji_listing WHERE city = ? AND price BETWEEN ? AND ?',
+      {
+        replacements: [city, startPrice, endPrice],
+        type: Sequelize.SELECT,
+      },
+    );
+    console.log('DEBUG-listingsByCityPriceRange');
+    console.log(listingsByCityPriceRange);
+    return listingsByCityPriceRange;
+  } catch (err) {
+    return err;
+  }
+}
+
 async function getAllListingsByProvince(provinceCode) {
   try {
     const [listingsByProvince] = await sequelize.query(
@@ -26,6 +77,57 @@ async function getAllListingsByProvince(provinceCode) {
       },
     );
     return listingsByProvince;
+  } catch (err) {
+    return err;
+  }
+}
+
+async function getAllListingsByProvinceCategory(provinceCode, category) {
+  try {
+    const [listingsByProvinceCategory] = await sequelize.query(
+      'SELECT * FROM fujiji_listing WHERE province_code = ? AND category = ?',
+      {
+        replacements: [provinceCode, category],
+        type: Sequelize.SELECT,
+      },
+    );
+    console.log('DEBUG-listingsByProvinceCategory');
+    console.log(listingsByProvinceCategory);
+    return listingsByProvinceCategory;
+  } catch (err) {
+    return err;
+  }
+}
+
+async function getAllListingsByProvinceCondition(provinceCode, condition) {
+  try {
+    const [listingsByProvinceCondition] = await sequelize.query(
+      'SELECT * FROM fujiji_listing WHERE province_code = ? AND condition = ?',
+      {
+        replacements: [provinceCode, condition],
+        type: Sequelize.SELECT,
+      },
+    );
+    console.log('DEBUG-listingsByProvinceConditon');
+    console.log(listingsByProvinceCondition);
+    return listingsByProvinceCondition;
+  } catch (err) {
+    return err;
+  }
+}
+
+async function getAllListingsByProvincePriceRange(provinceCode, startPrice, endPrice) {
+  try {
+    const [listingsByProvincePriceRange] = await sequelize.query(
+      'SELECT * FROM fujiji_listing WHERE province_code = ? AND price BETWEEN ? AND ?',
+      {
+        replacements: [provinceCode, startPrice, endPrice],
+        type: Sequelize.SELECT,
+      },
+    );
+    console.log('DEBUG-listingsByProvincePriceRange');
+    console.log(listingsByProvincePriceRange);
+    return listingsByProvincePriceRange;
   } catch (err) {
     return err;
   }
@@ -46,4 +148,10 @@ module.exports = {
   getAllListingsDefault,
   getAllListingsByCity,
   getAllListingsByProvince,
+  getAllListingsByCityCategory,
+  getAllListingsByProvinceCategory,
+  getAllListingsByCityCondition,
+  getAllListingsByProvinceCondition,
+  getAllListingsByCityPriceRange,
+  getAllListingsByProvincePriceRange,
 };

--- a/fujiji-server/src/repositories/user.js
+++ b/fujiji-server/src/repositories/user.js
@@ -1,4 +1,5 @@
 const { QueryTypes } = require('sequelize');
+const { logDebug } = require('../utils/logging');
 const sequelize = require('./db');
 
 async function testGetUser() {
@@ -14,6 +15,7 @@ async function getUserByEmail(email) {
   const [result] = await sequelize.query(
     `SELECT * FROM fujiji_user WHERE email_address='${email}'`,
   );
+  logDebug('DEBUG-getUserByEmail', result);
   return result[0];
 }
 
@@ -26,6 +28,7 @@ async function createUser(email, password, name, phoneNumber) {
       ($1, $2, $3, $4);`,
     { bind: [name, email, phoneNumber, password], type: QueryTypes.INSERT },
   );
+  logDebug('DEBUG-createUser', result);
   return result[0];
 }
 

--- a/fujiji-server/src/utils/logging.js
+++ b/fujiji-server/src/utils/logging.js
@@ -1,0 +1,6 @@
+function logDebug(title, message) {
+  console.log(title);
+  console.log(message);
+}
+
+module.exports = { logDebug };


### PR DESCRIPTION
# Description

- Created endpoints to filter listings as mentioned in the #64 
- A user must specify their location (either by `city` or `provinceCode`) when they want to view listings and also specify the filter criteria either by `category`, `condition`, or `priceRange`. So, the endpoint would look like `/listing?city=Winnipeg&category=Other` or `/listing?provinceCode=MB&condition=used` or `/listing?provinceCode=MB&priceRange=20&priceRange=50` 
- Created unit test for this.
- Closes #64 

# Demo

If you want to run the unit test:
```
npm test
```
It should run successfully as follows:
<img width="416" alt="testPassed" src="https://user-images.githubusercontent.com/57550160/156309698-527db4f9-e2fe-4d80-bc5f-e5967b8b89e6.png">

