### PR TITLE
feat/#87: Page for showcase individual listing

### DIFF
--- a/fujiji-client/src/__mocks__/mockAdListing.js
+++ b/fujiji-client/src/__mocks__/mockAdListing.js
@@ -5,10 +5,8 @@ const mockAdListings = [
     title: 'Wooden Table',
     price: 9999,
     description: 'Does not come with doggo :(',
-    location: {
-      city: 'Winnipeg',
-      provinceCode: 'MB',
-    },
+    city: 'Winnipeg',
+    province: 'MB',
     category: 'table',
     condition: 'new',
     postingDate: '2022-02-21',
@@ -20,10 +18,8 @@ const mockAdListings = [
     price: 123.23,
     description:
       'Lorem Ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum',
-    location: {
-      city: 'Vancouver',
-      provinceCode: 'BC',
-    },
+    city: 'Vancouver',
+    provinceCode: 'BC',
     category: 'sofa',
     condition: 'used',
     postingDate: '2022-02-21',
@@ -33,10 +29,8 @@ const mockAdListings = [
     imageAlt: 'Antique white chair',
     title: 'Antique Chair',
     price: 1900,
-    location: {
-      city: 'Toronto',
-      provinceCode: 'ON',
-    },
+    city: 'Toronto',
+    provinceCode: 'ON',
     category: 'chair',
     condition: 'used',
     postingDate: '2022-02-21',

--- a/fujiji-client/src/components/AdListingCard/AdListingCard.jsx
+++ b/fujiji-client/src/components/AdListingCard/AdListingCard.jsx
@@ -28,7 +28,8 @@ export default function AdListingCard({
   title,
   price,
   description = '',
-  location,
+  city,
+  province,
   condition,
   onClick = undefined,
   postingDate,
@@ -39,8 +40,7 @@ export default function AdListingCard({
     ? format(new Date(parsedDate), 'dd MMM yyyy')
     : '';
 
-  const { city, provinceCode } = location;
-  const formattedLocation = `${city}, ${provinceCode}`;
+  const formattedLocation = `${city}, ${province}`;
 
   return (
     <Box
@@ -125,10 +125,8 @@ AdListingCard.propTypes = {
   title: PropTypes.string,
   price: PropTypes.number,
   description: PropTypes.string,
-  location: PropTypes.shape({
-    city: PropTypes.string,
-    provinceCode: PropTypes.string,
-  }),
+  city: PropTypes.string,
+  province: PropTypes.string,
   condition: PropTypes.string,
   onClick: PropTypes.func,
   postingDate: PropTypes.string,

--- a/fujiji-client/src/components/Listing/Listing.jsx
+++ b/fujiji-client/src/components/Listing/Listing.jsx
@@ -1,6 +1,12 @@
 import PropTypes from 'prop-types';
 import {
-  Box, Button, Flex, Text, Image, Icon,
+  Box,
+  Button,
+  Flex,
+  Text,
+  Image,
+  Icon,
+  Link,
 } from '@chakra-ui/react';
 import { MdLocationOn } from 'react-icons/md';
 import { BsCalendar } from 'react-icons/bs';
@@ -39,19 +45,20 @@ export default function Listing({
   condition,
   description,
   imageUrl,
-  location,
+  city,
+  province,
   postingDate,
   price,
   title,
-  onContactClick,
+  onContactClick = () => {},
+  contactEmail,
 }) {
   const formattedPrice = price.toLocaleString();
   const parsedDate = parse(postingDate, 'yyyy-MM-dd', new Date());
   const formattedDate = isValid(parsedDate)
     ? format(new Date(parsedDate), 'dd MMMM yyyy')
     : '';
-  const { city, provinceCode } = location;
-  const formattedLocation = `${city}, ${provinceCode}`;
+  const formattedLocation = `${city}, ${province}`;
 
   return (
     <Flex d="inline-flex" flexDir={['column', null, 'row', 'row']}>
@@ -75,7 +82,7 @@ export default function Listing({
         minW={['320px', null, '360px', '400px']}
         maxW="500px"
         mt={['6', '0']}
-        ml={['0', '10']}
+        mx={['2', '5', '10']}
       >
         <Text fontSize="3xl" fontWeight="bold">
           {title}
@@ -122,9 +129,18 @@ export default function Listing({
             {' '}
             {formattedPrice}
           </Box>
-          <Button aria-label="contact-seller-button" colorScheme="teal" size="md" onClick={() => onContactClick()}>
-            Contact
-          </Button>
+          <Link
+            href={`mailto:${contactEmail}`}
+            _hover={{ textDecoration: 'none' }}
+          >
+            <Button
+              aria-label="contact-seller-button"
+              colorScheme="teal"
+              onClick={onContactClick}
+            >
+              Contact
+            </Button>
+          </Link>
         </Box>
       </Flex>
     </Flex>
@@ -143,11 +159,10 @@ Listing.propTypes = {
   price: PropTypes.number,
   description: PropTypes.string,
   category: PropTypes.string,
-  location: PropTypes.shape({
-    city: PropTypes.string,
-    provinceCode: PropTypes.string,
-  }),
+  city: PropTypes.string,
+  province: PropTypes.string,
   condition: PropTypes.string,
   onContactClick: PropTypes.func,
   postingDate: PropTypes.string,
+  contactEmail: PropTypes.string,
 };

--- a/fujiji-client/src/pages/listing/[id].jsx
+++ b/fujiji-client/src/pages/listing/[id].jsx
@@ -1,0 +1,48 @@
+import { Center } from '@chakra-ui/react';
+import PropTypes from 'prop-types';
+import { Listing, withSession } from '../../components';
+import { getListingById } from '../../server/api';
+
+function IndividualListingPage({ data }) {
+  if (data.error) {
+    return <Center>{data.error}</Center>;
+  }
+
+  return (
+    <Center id={`listingContainer-${data.listingID}`} px="1" py="6">
+      <Listing {...data} />
+    </Center>
+  );
+}
+
+export default withSession(IndividualListingPage);
+
+export async function getServerSideProps(context) {
+  const listingId = context.query.id;
+
+  const data = await getListingById(listingId);
+
+  return {
+    props: {
+      data,
+    },
+  };
+}
+
+IndividualListingPage.propTypes = {
+  data: PropTypes.shape({
+    userID: PropTypes.number,
+    listingID: PropTypes.number,
+    title: PropTypes.string,
+    condition: PropTypes.string,
+    category: PropTypes.string,
+    city: PropTypes.string,
+    province: PropTypes.string,
+    imageUrl: PropTypes.string,
+    price: PropTypes.number,
+    description: PropTypes.string,
+    creationDate: PropTypes.string,
+    contactEmail: PropTypes.string,
+    error: PropTypes.string,
+  }),
+};

--- a/fujiji-client/src/server/api/getListingById.js
+++ b/fujiji-client/src/server/api/getListingById.js
@@ -8,6 +8,7 @@ export default async function getListingById(listingId) {
     );
     const { listing } = result.data;
     return {
+      userID: parseInt(listing.user_id, 10),
       listingID: parseInt(listing.listing_id, 10),
       title: listing.title,
       condition: listing.condition,
@@ -17,7 +18,8 @@ export default async function getListingById(listingId) {
       imageUrl: listing.image_url,
       price: listing.price,
       description: listing.description,
-      creationDate: listing.creation_date,
+      postingDate: listing.creation_date,
+      contactEmail: listing.contact_email,
     };
   } catch (error) {
     if (error.response) {

--- a/fujiji-client/src/server/api/getListingByUserId.js
+++ b/fujiji-client/src/server/api/getListingByUserId.js
@@ -26,10 +26,8 @@ export default async function getListingByUserId(userId, authToken) {
         title: listing.title,
         condition: listing.condition,
         category: listing.category,
-        location: {
-          city: listing.city,
-          provinceCode: listing.province_code,
-        },
+        city: listing.city,
+        province: listing.province_code,
         imageUrl: listing.image_url,
         price: listing.price,
         description: listing.description,

--- a/fujiji-server/src/controllers/listing.js
+++ b/fujiji-server/src/controllers/listing.js
@@ -13,6 +13,7 @@ const {
   deleteListingById,
   getAllListingsDefault,
 } = require('../repositories/listing');
+const { getUserByID } = require('../repositories/user');
 
 const APIError = require('../errors/api');
 const ListingNotFoundError = require('../errors/listing/listingNotFound');
@@ -136,7 +137,11 @@ async function getByListingId(req, res, next) {
       );
     }
 
-    return res.status(200).json({ listing });
+    const user = await getUserByID(listing.user_id);
+
+    return res
+      .status(200)
+      .json({ listing: { ...listing, contact_email: user.email_address } });
   } catch (err) {
     return next(new APIError());
   }


### PR DESCRIPTION
# Description

The page is located at `listing/[id]`

For now we the Contact seller button only prompt an email

Make `GET /listing/:id` to also return the `contact_email` field

Breakdown `location` prop into `city` and `province`

Closes #87 

# Demo

https://user-images.githubusercontent.com/36686154/157599476-1fa249fa-09c5-4bf2-b321-6f9f7a195801.mov


