### PR TITLE
fix/#92: Show edit button for seller in the individual listing page

### DIFF
--- a/fujiji-client/.eslintrc
+++ b/fujiji-client/.eslintrc
@@ -9,6 +9,7 @@
     "airbnb/hooks"
   ],
   "parserOptions": {
+    "ecmaVersion": 2020,
     "ecmaFeatures": {
       "jsx": "true"
     }

--- a/fujiji-client/src/components/Listing/Listing.jsx
+++ b/fujiji-client/src/components/Listing/Listing.jsx
@@ -1,17 +1,12 @@
 import PropTypes from 'prop-types';
 import {
-  Box,
-  Button,
-  Flex,
-  Text,
-  Image,
-  Icon,
-  Link,
+  Box, Button, Flex, Text, Image, Icon, Link,
 } from '@chakra-ui/react';
 import { MdLocationOn } from 'react-icons/md';
 import { BsCalendar } from 'react-icons/bs';
 import { BiCategory } from 'react-icons/bi';
 import { format, isValid, parse } from 'date-fns';
+import { useRouter } from 'next/router';
 import ConditionBadge from '../ConditionBadge/ConditionBadge';
 
 function ListingInfoBox({ icon, infoField, infoContent }) {
@@ -41,6 +36,8 @@ function ListingInfoBox({ icon, infoField, infoContent }) {
 }
 
 export default function Listing({
+  isSeller = false,
+  listingID,
   category,
   condition,
   description,
@@ -59,6 +56,11 @@ export default function Listing({
     ? format(new Date(parsedDate), 'dd MMMM yyyy')
     : '';
   const formattedLocation = `${city}, ${province}`;
+  const router = useRouter();
+
+  const onEditClick = () => {
+    router.push(`/listing/edit/${listingID}`);
+  };
 
   return (
     <Flex d="inline-flex" flexDir={['column', null, 'row', 'row']}>
@@ -129,18 +131,29 @@ export default function Listing({
             {' '}
             {formattedPrice}
           </Box>
-          <Link
-            href={`mailto:${contactEmail}`}
-            _hover={{ textDecoration: 'none' }}
-          >
+          {isSeller && (
             <Button
-              aria-label="contact-seller-button"
+              aria-label="edit-listing-button"
               colorScheme="teal"
-              onClick={onContactClick}
+              onClick={onEditClick}
             >
-              Contact
+              Edit
             </Button>
-          </Link>
+          )}
+          {!isSeller && (
+            <Link
+              href={`mailto:${contactEmail}`}
+              _hover={{ textDecoration: 'none' }}
+            >
+              <Button
+                aria-label="contact-seller-button"
+                colorScheme="teal"
+                onClick={onContactClick}
+              >
+                Contact
+              </Button>
+            </Link>
+          )}
         </Box>
       </Flex>
     </Flex>
@@ -154,6 +167,8 @@ ListingInfoBox.propTypes = {
 };
 
 Listing.propTypes = {
+  isSeller: PropTypes.bool,
+  listingID: PropTypes.number,
   imageUrl: PropTypes.string,
   title: PropTypes.string,
   price: PropTypes.number,

--- a/fujiji-client/src/components/Listing/Listing.spec.jsx
+++ b/fujiji-client/src/components/Listing/Listing.spec.jsx
@@ -5,11 +5,23 @@ import mockAdListing from '../../__mocks__/mockAdListing';
 
 describe('Listing', () => {
   it('should render properly', () => {
-    const { getByText } = render(<Listing {...mockAdListing[0]} />);
+    const { getByText, getByLabelText, queryByLabelText } = render(<Listing {...mockAdListing[0]} />);
     expect(getByText(mockAdListing[0].title)).toBeInTheDocument();
     expect(getByText(mockAdListing[0].description)).toBeInTheDocument();
     expect(getByText('new')).toBeInTheDocument();
     expect(getByText('21 February 2022')).toBeInTheDocument();
+    expect(getByLabelText('contact-seller-button')).toBeInTheDocument();
+    expect(queryByLabelText('edit-listing-button')).toBeFalsy();
+  });
+
+  it("should render edit button if this listing is seller's", () => {
+    const { getByText, getByLabelText, queryByLabelText } = render(<Listing {...mockAdListing[0]} isSeller />);
+    expect(getByText(mockAdListing[0].title)).toBeInTheDocument();
+    expect(getByText(mockAdListing[0].description)).toBeInTheDocument();
+    expect(getByText('new')).toBeInTheDocument();
+    expect(getByText('21 February 2022')).toBeInTheDocument();
+    expect(getByLabelText('edit-listing-button')).toBeInTheDocument();
+    expect(queryByLabelText('contact-seller-button')).toBeFalsy();
   });
 
   it('should render with empty description', () => {

--- a/fujiji-client/src/components/Listing/Listing.stories.jsx
+++ b/fujiji-client/src/components/Listing/Listing.stories.jsx
@@ -35,3 +35,9 @@ export const EmptyDescription = Template.bind({});
 EmptyDescription.args = {
   ...mockAdListing[2],
 };
+
+export const SellerListing = Template.bind({});
+SellerListing.args = {
+  isSeller: true,
+  ...mockAdListing[0],
+};

--- a/fujiji-client/src/pages/listing/[id].jsx
+++ b/fujiji-client/src/pages/listing/[id].jsx
@@ -1,21 +1,36 @@
 import { Center } from '@chakra-ui/react';
 import PropTypes from 'prop-types';
-import { Listing, withSession } from '../../components';
+import { Listing } from '../../components';
+import { useSession } from '../../context/session';
 import { getListingById } from '../../server/api';
 
 function IndividualListingPage({ data }) {
+  const session = useSession();
+
+  if (typeof window === 'undefined') {
+    return null;
+  }
+
   if (data.error) {
     return <Center>{data.error}</Center>;
   }
 
+  const listingProps = {
+    ...data,
+    isSeller:
+      typeof window === 'undefined'
+        ? false
+        : parseInt(data.userID, 10) === parseInt(session.userData?.userID, 10),
+  };
+
   return (
     <Center id={`listingContainer-${data.listingID}`} px="1" py="6">
-      <Listing {...data} />
+      <Listing {...listingProps} />
     </Center>
   );
 }
 
-export default withSession(IndividualListingPage);
+export default IndividualListingPage;
 
 export async function getServerSideProps(context) {
   const listingId = context.query.id;

--- a/fujiji-client/src/pages/search/index.jsx
+++ b/fujiji-client/src/pages/search/index.jsx
@@ -4,7 +4,7 @@ import {
 import { useRouter } from 'next/router';
 import PropTypes from 'prop-types';
 import { useEffect, useState } from 'react';
-import { AdListingCard} from '../../components';
+import { AdListingCard } from '../../components';
 import { getAllListings } from '../../server/api';
 
 function SearchPage() {


### PR DESCRIPTION
# Description

If the seller visit their own listing. They will see edit button instead of contact button.

Closes #92 

# Demo

https://user-images.githubusercontent.com/36686154/160737508-5920b99e-ccc5-4393-9097-52643c40d964.mov


