### PR TITLE
feat/#104: implement POST comment endpoint

### DIFF
--- a/fujiji-server/__test__/controllers/comment.test.js
+++ b/fujiji-server/__test__/controllers/comment.test.js
@@ -1,0 +1,102 @@
+const request = require('supertest');
+const app = require('../../src/app');
+const { mockUser, seedTestDB, tearDownDB } = require('../dbSetup');
+
+describe('POST /comment/:listing_id', () => {
+  let token;
+  let userid;
+
+  beforeEach(async () => {
+    await tearDownDB();
+    await seedTestDB();
+    const mockUserReqBody = {
+      email: mockUser.email,
+      password: mockUser.password,
+    };
+    const signinRes = await request(app)
+      .post('/auth/signin')
+      .send(mockUserReqBody);
+    token = signinRes.body.authToken;
+    userid = signinRes.body.userId;
+  });
+
+  afterEach(async () => {
+    await tearDownDB();
+  });
+
+  it('Successfully created a comment', async () => {
+    const mockPostListingReqBody = {
+      userID: userid,
+      title: 'Dining Table In Good Condition',
+      condition: 'used',
+      category: 'Table',
+      city: 'Winnipeg',
+      provinceCode: 'MB',
+      imageURL: 'https://source.unsplash.com/gySMaocSdqs/',
+      price: 50,
+      description: 'Just used for 3 years',
+    };
+
+    const mockPostCommentReqBody = {
+      comment: 'mock comment',
+    };
+
+    const postListingRes = await request(app)
+      .post('/listing')
+      .set('Authorization', `Bearer ${token}`)
+      .send(mockPostListingReqBody);
+
+    const postCommentRes = await request(app)
+      .post(`/comment/${postListingRes.body.listingId}`)
+      .set('Authorization', `Bearer ${token}`)
+      .send(mockPostCommentReqBody);
+
+    expect(postCommentRes.statusCode).toEqual(200);
+  });
+
+  it('Should return 404 error if listing does not exist', async () => {
+    const mockPostCommentReqBody = {
+      comment: 'mock comment',
+    };
+
+    const postCommentRes = await request(app)
+      .post('/comment/123123')
+      .set('Authorization', `Bearer ${token}`)
+      .send(mockPostCommentReqBody);
+
+    expect(postCommentRes.statusCode).toEqual(404);
+  });
+
+  it('Should return 400 error if comment field is not provided', async () => {
+    const mockPostListingReqBody = {
+      userID: userid,
+      title: 'Dining Table In Good Condition',
+      condition: 'used',
+      category: 'Table',
+      city: 'Winnipeg',
+      provinceCode: 'MB',
+      imageURL: 'https://source.unsplash.com/gySMaocSdqs/',
+      price: 50,
+      description: 'Just used for 3 years',
+    };
+
+    const postListingRes = await request(app)
+      .post('/listing')
+      .set('Authorization', `Bearer ${token}`)
+      .send(mockPostListingReqBody);
+
+    let postCommentRes = await request(app)
+      .post(`/comment/${postListingRes.body.listingId}`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({});
+
+    expect(postCommentRes.statusCode).toEqual(400);
+
+    postCommentRes = await request(app)
+      .post(`/comment/${postListingRes.body.listingId}`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ comment: '' });
+
+    expect(postCommentRes.statusCode).toEqual(400);
+  });
+});

--- a/fujiji-server/migration-scripts/fix_isAuthor_typo.sql
+++ b/fujiji-server/migration-scripts/fix_isAuthor_typo.sql
@@ -1,0 +1,1 @@
+EXEC sp_rename 'fujiji_comments.isAuther', 'isAuthor', 'COLUMN'

--- a/fujiji-server/src/app.js
+++ b/fujiji-server/src/app.js
@@ -27,6 +27,7 @@ app.use(express.urlencoded({ extended: true }));
 app.use('/', routes);
 
 // for debugging purposes if you are actually logged in
+/* istanbul ignore next */
 app.get('/authstatus', authentication, async (req, res) => {
   const { userData } = req.locals;
 
@@ -36,15 +37,18 @@ app.get('/authstatus', authentication, async (req, res) => {
 });
 
 // for debugging purposes to check if we able to connect to DB
+/* istanbul ignore next */
 app.get('/appstatus', async (req, res) => {
   const response = {
     message: 'Hello from the server!!!',
   };
   let [allUser] = '';
   let [allListing] = '';
+  let [allComments] = '';
   try {
     [allUser] = await sequelize.query('SELECT * FROM fujiji_user');
     [allListing] = await sequelize.query('SELECT * FROM fujiji_listing');
+    [allComments] = await sequelize.query('SELECT * FROM fujiji_comments');
   } catch (err) {
     console.log(err);
   }
@@ -53,9 +57,11 @@ app.get('/appstatus', async (req, res) => {
     response,
     allUser,
     allListing,
+    allComments,
   });
 });
 
+/* istanbul ignore next */
 app.get('/', async (req, res) => {
   const response = {
     message: 'Test for homepage. This should be showing pls',
@@ -65,6 +71,7 @@ app.get('/', async (req, res) => {
 });
 
 if (process.env.NODE_ENV !== 'test') {
+  /* istanbul ignore next */
   app.listen(port, async () => {
     console.log(`Server is up on port ${appUrl}:${port}`);
 

--- a/fujiji-server/src/config/config.js
+++ b/fujiji-server/src/config/config.js
@@ -1,3 +1,5 @@
+/* istanbul ignore file */
+
 const config = {
   APP_URL: process.env.APP_URL,
   PORT: process.env.PORT,

--- a/fujiji-server/src/controllers/comment.js
+++ b/fujiji-server/src/controllers/comment.js
@@ -1,0 +1,40 @@
+const { createComment } = require('../repositories/comment');
+const { getListingById } = require('../repositories/listing');
+
+const { APIError, ListingNotFound } = require('../errors');
+
+async function postComment(req, res, next) {
+  const { comment } = req.body;
+  const { listing_id: listingID } = req.params;
+  const { id } = req.locals.userData;
+  const userID = parseInt(id, 10);
+
+  if (!comment) {
+    return res.status(400).json({ error: "'comment' field can not be empty" });
+  }
+
+  const listing = await getListingById(parseInt(listingID, 10));
+
+  if (!listing) {
+    return next(
+      new ListingNotFound(`listing with id:${listingID} is not found`),
+    );
+  }
+
+  const isAuthor = userID === parseInt(listing.user_id, 10) ? 1 : 0;
+
+  try {
+    const insertCommentResult = await createComment(
+      userID,
+      listingID,
+      comment,
+      isAuthor,
+    );
+
+    return res.status(200).json({ id: insertCommentResult.comment_id });
+  } catch (err) {
+    return next(new APIError(err, 500));
+  }
+}
+
+module.exports = { postComment };

--- a/fujiji-server/src/errors/index.js
+++ b/fujiji-server/src/errors/index.js
@@ -1,3 +1,3 @@
 const APIError = require('./api');
 
-module.exports = { APIError, ...require('./auth') };
+module.exports = { APIError, ...require('./auth'), ...require('./listing') };

--- a/fujiji-server/src/errors/listing/index.js
+++ b/fujiji-server/src/errors/listing/index.js
@@ -1,0 +1,7 @@
+const ListingInvalidPriceRange = require('./listingInvalidPriceRange');
+const ListingNotFound = require('./listingNotFound');
+
+module.exports = {
+  ListingInvalidPriceRange,
+  ListingNotFound,
+};

--- a/fujiji-server/src/errors/user/userNotFound.js
+++ b/fujiji-server/src/errors/user/userNotFound.js
@@ -2,6 +2,7 @@ const APIError = require('../api');
 
 class UserNotFoundError extends APIError {
   constructor(message) {
+    /* istanbul ignore next */
     super(message || 'No user with such id is found.', 404);
   }
 }

--- a/fujiji-server/src/repositories/comment.js
+++ b/fujiji-server/src/repositories/comment.js
@@ -1,0 +1,23 @@
+const { Sequelize } = require('sequelize');
+const { logDebug } = require('../utils/logging');
+const sequelize = require('./db');
+
+async function createComment(userID, listingID, comment, isAuthor) {
+  const [result] = await sequelize.query(
+    `INSERT INTO fujiji_comments
+            (user_id, listing_id, comment, isHighlighted, isAuthor, creation_date)
+          OUTPUT INSERTED.*
+          VALUES
+            ($1, $2, $3, $4, $5, getutcdate());`,
+    {
+      bind: [userID, listingID, comment, 0, isAuthor],
+      type: Sequelize.INSERT,
+    },
+  );
+  logDebug('DEBUG-createComment', result);
+  return result[0];
+}
+
+module.exports = {
+  createComment,
+};

--- a/fujiji-server/src/routes/comment.js
+++ b/fujiji-server/src/routes/comment.js
@@ -1,0 +1,11 @@
+const express = require('express');
+const authentication = require('../middleware/authentication');
+const {
+  postComment,
+} = require('../controllers/comment');
+
+const router = express.Router();
+
+router.post('/:listing_id', authentication, postComment);
+
+module.exports = router;

--- a/fujiji-server/src/routes/index.js
+++ b/fujiji-server/src/routes/index.js
@@ -4,10 +4,12 @@ const router = express.Router();
 const user = require('./user');
 const listing = require('./listing');
 const auth = require('./auth');
+const comment = require('./comment');
 
 // --- Routes ---
 router.use('/user', user);
 router.use('/listing', listing);
 router.use('/auth', auth);
+router.use('/comment', comment);
 
 module.exports = router;

--- a/fujiji-server/src/utils/logging.js
+++ b/fujiji-server/src/utils/logging.js
@@ -1,3 +1,5 @@
+/* istanbul ignore file */
+
 function logDebug(title, message) {
   if (process.env.NODE_ENV !== 'test') {
     console.log(title);


### PR DESCRIPTION
# Description

Endpoint
- Implemented `POST /comment/listing_id`.
- This requires authentication.
- If comment field is not provided or empty, we return `400 Bad Request`
- We also check if `listing_id` exist in the db and whether the commenter also the poster of the listing.

Misc:
- Fixed typo on `isAuther` table using the new migration script
- Test coverage cleanup