### PR TITLE
Feat/#103 implement GET comment endpoint

### DIFF
--- a/fujiji-server/__test__/controllers/comment.test.js
+++ b/fujiji-server/__test__/controllers/comment.test.js
@@ -198,6 +198,30 @@ describe('Test /comment endpoints', () => {
       expect(getCommentRes.body.comments.length).toEqual(2);
     });
 
+    it('Successfully return empty list when no comment is posted', async () => {
+      const mockPostListingReqBody = {
+        userID: userid,
+        title: 'Dining Table In Good Condition',
+        condition: 'used',
+        category: 'Table',
+        city: 'Winnipeg',
+        provinceCode: 'MB',
+        imageURL: 'https://source.unsplash.com/gySMaocSdqs/',
+        price: 50,
+        description: 'Just used for 3 years',
+      };
+
+      const postListingRes = await request(app)
+        .post('/listing')
+        .set('Authorization', `Bearer ${token}`)
+        .send(mockPostListingReqBody);
+
+      const getCommentRes = await request(app)
+        .get(`/comment/${postListingRes.body.listingId}`);
+      expect(getCommentRes.statusCode).toEqual(200);
+      expect(getCommentRes.body.comments.length).toEqual(0);
+    });
+
     it('Should return 404 error if listing does not exist', async () => {
       const getCommentRes = await request(app)
         .get('/comment/123123');

--- a/fujiji-server/__test__/controllers/comment.test.js
+++ b/fujiji-server/__test__/controllers/comment.test.js
@@ -2,101 +2,207 @@ const request = require('supertest');
 const app = require('../../src/app');
 const { mockUser, seedTestDB, tearDownDB } = require('../dbSetup');
 
-describe('POST /comment/:listing_id', () => {
-  let token;
-  let userid;
+describe('Test /comment endpoints', () => {
+  describe('POST /comment/:listing_id', () => {
+    let token;
+    let userid;
 
-  beforeEach(async () => {
-    await tearDownDB();
-    await seedTestDB();
-    const mockUserReqBody = {
-      email: mockUser.email,
-      password: mockUser.password,
-    };
-    const signinRes = await request(app)
-      .post('/auth/signin')
-      .send(mockUserReqBody);
-    token = signinRes.body.authToken;
-    userid = signinRes.body.userId;
+    beforeEach(async () => {
+      await tearDownDB();
+      await seedTestDB();
+      const mockUserReqBody = {
+        email: mockUser.email,
+        password: mockUser.password,
+      };
+      const signinRes = await request(app)
+        .post('/auth/signin')
+        .send(mockUserReqBody);
+      token = signinRes.body.authToken;
+      userid = signinRes.body.userId;
+    });
+
+    afterEach(async () => {
+      await tearDownDB();
+    });
+
+    it('Successfully created a comment', async () => {
+      const mockPostListingReqBody = {
+        userID: userid,
+        title: 'Dining Table In Good Condition',
+        condition: 'used',
+        category: 'Table',
+        city: 'Winnipeg',
+        provinceCode: 'MB',
+        imageURL: 'https://source.unsplash.com/gySMaocSdqs/',
+        price: 50,
+        description: 'Just used for 3 years',
+      };
+
+      const mockPostCommentReqBody = {
+        comment: 'mock comment',
+      };
+
+      const postListingRes = await request(app)
+        .post('/listing')
+        .set('Authorization', `Bearer ${token}`)
+        .send(mockPostListingReqBody);
+
+      const postCommentRes = await request(app)
+        .post(`/comment/${postListingRes.body.listingId}`)
+        .set('Authorization', `Bearer ${token}`)
+        .send(mockPostCommentReqBody);
+
+      expect(postCommentRes.statusCode).toEqual(200);
+    });
+
+    it('Should return 404 error if listing does not exist', async () => {
+      const mockPostCommentReqBody = {
+        comment: 'mock comment',
+      };
+
+      const postCommentRes = await request(app)
+        .post('/comment/123123')
+        .set('Authorization', `Bearer ${token}`)
+        .send(mockPostCommentReqBody);
+
+      expect(postCommentRes.statusCode).toEqual(404);
+    });
+
+    it('Should return 400 error if comment field is not provided', async () => {
+      const mockPostListingReqBody = {
+        userID: userid,
+        title: 'Dining Table In Good Condition',
+        condition: 'used',
+        category: 'Table',
+        city: 'Winnipeg',
+        provinceCode: 'MB',
+        imageURL: 'https://source.unsplash.com/gySMaocSdqs/',
+        price: 50,
+        description: 'Just used for 3 years',
+      };
+
+      const postListingRes = await request(app)
+        .post('/listing')
+        .set('Authorization', `Bearer ${token}`)
+        .send(mockPostListingReqBody);
+
+      let postCommentRes = await request(app)
+        .post(`/comment/${postListingRes.body.listingId}`)
+        .set('Authorization', `Bearer ${token}`)
+        .send({});
+
+      expect(postCommentRes.statusCode).toEqual(400);
+
+      postCommentRes = await request(app)
+        .post(`/comment/${postListingRes.body.listingId}`)
+        .set('Authorization', `Bearer ${token}`)
+        .send({ comment: '' });
+
+      expect(postCommentRes.statusCode).toEqual(400);
+    });
   });
 
-  afterEach(async () => {
-    await tearDownDB();
-  });
+  describe('GET /comment/:listing_id', () => {
+    let token;
+    let userid;
 
-  it('Successfully created a comment', async () => {
-    const mockPostListingReqBody = {
-      userID: userid,
-      title: 'Dining Table In Good Condition',
-      condition: 'used',
-      category: 'Table',
-      city: 'Winnipeg',
-      provinceCode: 'MB',
-      imageURL: 'https://source.unsplash.com/gySMaocSdqs/',
-      price: 50,
-      description: 'Just used for 3 years',
-    };
+    beforeEach(async () => {
+      await tearDownDB();
+      await seedTestDB();
+      const mockUserReqBody = {
+        email: mockUser.email,
+        password: mockUser.password,
+      };
+      const signinRes = await request(app)
+        .post('/auth/signin')
+        .send(mockUserReqBody);
+      token = signinRes.body.authToken;
+      userid = signinRes.body.userId;
+    });
 
-    const mockPostCommentReqBody = {
-      comment: 'mock comment',
-    };
+    afterEach(async () => {
+      await tearDownDB();
+    });
 
-    const postListingRes = await request(app)
-      .post('/listing')
-      .set('Authorization', `Bearer ${token}`)
-      .send(mockPostListingReqBody);
+    it('Successfully fetch a comment that was just created', async () => {
+      const mockPostListingReqBody = {
+        userID: userid,
+        title: 'Dining Table In Good Condition',
+        condition: 'used',
+        category: 'Table',
+        city: 'Winnipeg',
+        provinceCode: 'MB',
+        imageURL: 'https://source.unsplash.com/gySMaocSdqs/',
+        price: 50,
+        description: 'Just used for 3 years',
+      };
 
-    const postCommentRes = await request(app)
-      .post(`/comment/${postListingRes.body.listingId}`)
-      .set('Authorization', `Bearer ${token}`)
-      .send(mockPostCommentReqBody);
+      const mockPostCommentReqBody = {
+        comment: 'mock comment',
+      };
 
-    expect(postCommentRes.statusCode).toEqual(200);
-  });
+      const postListingRes = await request(app)
+        .post('/listing')
+        .set('Authorization', `Bearer ${token}`)
+        .send(mockPostListingReqBody);
 
-  it('Should return 404 error if listing does not exist', async () => {
-    const mockPostCommentReqBody = {
-      comment: 'mock comment',
-    };
+      await request(app)
+        .post(`/comment/${postListingRes.body.listingId}`)
+        .set('Authorization', `Bearer ${token}`)
+        .send(mockPostCommentReqBody);
 
-    const postCommentRes = await request(app)
-      .post('/comment/123123')
-      .set('Authorization', `Bearer ${token}`)
-      .send(mockPostCommentReqBody);
+      const getCommentRes = await request(app)
+        .get(`/comment/${postListingRes.body.listingId}`);
+      expect(getCommentRes.statusCode).toEqual(200);
+    });
 
-    expect(postCommentRes.statusCode).toEqual(404);
-  });
+    it('Successfully fetch >1 comment', async () => {
+      const mockPostListingReqBody = {
+        userID: userid,
+        title: 'Dining Table In Good Condition',
+        condition: 'used',
+        category: 'Table',
+        city: 'Winnipeg',
+        provinceCode: 'MB',
+        imageURL: 'https://source.unsplash.com/gySMaocSdqs/',
+        price: 50,
+        description: 'Just used for 3 years',
+      };
 
-  it('Should return 400 error if comment field is not provided', async () => {
-    const mockPostListingReqBody = {
-      userID: userid,
-      title: 'Dining Table In Good Condition',
-      condition: 'used',
-      category: 'Table',
-      city: 'Winnipeg',
-      provinceCode: 'MB',
-      imageURL: 'https://source.unsplash.com/gySMaocSdqs/',
-      price: 50,
-      description: 'Just used for 3 years',
-    };
+      const mockPostCommentReqBody1 = {
+        comment: 'mock comment1',
+      };
 
-    const postListingRes = await request(app)
-      .post('/listing')
-      .set('Authorization', `Bearer ${token}`)
-      .send(mockPostListingReqBody);
+      const mockPostCommentReqBody2 = {
+        comment: 'mock comment2',
+      };
 
-    let postCommentRes = await request(app)
-      .post(`/comment/${postListingRes.body.listingId}`)
-      .set('Authorization', `Bearer ${token}`)
-      .send({});
+      const postListingRes = await request(app)
+        .post('/listing')
+        .set('Authorization', `Bearer ${token}`)
+        .send(mockPostListingReqBody);
 
-    expect(postCommentRes.statusCode).toEqual(400);
+      await request(app)
+        .post(`/comment/${postListingRes.body.listingId}`)
+        .set('Authorization', `Bearer ${token}`)
+        .send(mockPostCommentReqBody1);
 
-    postCommentRes = await request(app)
-      .post(`/comment/${postListingRes.body.listingId}`)
-      .set('Authorization', `Bearer ${token}`)
-      .send({ comment: '' });
+      await request(app)
+        .post(`/comment/${postListingRes.body.listingId}`)
+        .set('Authorization', `Bearer ${token}`)
+        .send(mockPostCommentReqBody2);
 
-    expect(postCommentRes.statusCode).toEqual(400);
+      const getCommentRes = await request(app)
+        .get(`/comment/${postListingRes.body.listingId}`);
+      expect(getCommentRes.statusCode).toEqual(200);
+      expect(getCommentRes.body.comments.length).toEqual(2);
+    });
+
+    it('Should return 404 error if listing does not exist', async () => {
+      const getCommentRes = await request(app)
+        .get('/comment/123123');
+
+      expect(getCommentRes.statusCode).toEqual(404);
+    });
   });
 });

--- a/fujiji-server/__test__/controllers/comment.test.js
+++ b/fujiji-server/__test__/controllers/comment.test.js
@@ -154,6 +154,7 @@ describe('Test /comment endpoints', () => {
       const getCommentRes = await request(app)
         .get(`/comment/${postListingRes.body.listingId}`);
       expect(getCommentRes.statusCode).toEqual(200);
+      expect(getCommentRes.body.comments[0].name).toEqual('test-user');
     });
 
     it('Successfully fetch >1 comment', async () => {

--- a/fujiji-server/migration-scripts/add_comment_modified_date.sql
+++ b/fujiji-server/migration-scripts/add_comment_modified_date.sql
@@ -1,0 +1,1 @@
+ALTER TABLE fujiji_comments ADD modified_date DATETIME;

--- a/fujiji-server/src/controllers/comment.js
+++ b/fujiji-server/src/controllers/comment.js
@@ -6,6 +6,7 @@ const { getListingById } = require('../repositories/listing');
 
 const { APIError, ListingNotFound } = require('../errors');
 
+// PURPOSE: implement the post comment endpoint
 async function postComment(req, res, next) {
   const { comment } = req.body;
   const { listing_id: listingID } = req.params;
@@ -40,6 +41,7 @@ async function postComment(req, res, next) {
   }
 }
 
+// PURPOSE: implement the get comments by listing id endpoint
 async function getListingComments(req, res, next) {
   const { listing_id: listingID } = req.params;
 

--- a/fujiji-server/src/controllers/comment.js
+++ b/fujiji-server/src/controllers/comment.js
@@ -1,4 +1,7 @@
-const { createComment } = require('../repositories/comment');
+const {
+  createComment,
+  getComments,
+} = require('../repositories/comment');
 const { getListingById } = require('../repositories/listing');
 
 const { APIError, ListingNotFound } = require('../errors');
@@ -37,4 +40,24 @@ async function postComment(req, res, next) {
   }
 }
 
-module.exports = { postComment };
+async function getListingComments(req, res, next) {
+  const { listing_id: listingID } = req.params;
+
+  const listing = await getListingById(parseInt(listingID, 10));
+
+  if (!listing) {
+    return next(
+      new ListingNotFound(`listing with id:${listingID} is not found`),
+    );
+  }
+
+  try {
+    const comments = await getComments(listingID);
+
+    return res.status(200).json({ comments });
+  } catch (err) {
+    return next(new APIError(err, 500));
+  }
+}
+
+module.exports = { postComment, getListingComments };

--- a/fujiji-server/src/repositories/comment.js
+++ b/fujiji-server/src/repositories/comment.js
@@ -18,6 +18,19 @@ async function createComment(userID, listingID, comment, isAuthor) {
   return result[0];
 }
 
+async function getComments(listingID) {
+  const [result] = await sequelize.query(
+    'SELECT * FROM fujiji_comments WHERE listing_id = ?;',
+    {
+      replacements: [listingID],
+      type: Sequelize.SELECT,
+    },
+  );
+  logDebug('DEBUG-getComments', result);
+  return result;
+}
+
 module.exports = {
   createComment,
+  getComments,
 };

--- a/fujiji-server/src/repositories/comment.js
+++ b/fujiji-server/src/repositories/comment.js
@@ -22,7 +22,11 @@ async function createComment(userID, listingID, comment, isAuthor) {
 // PURPOSE: used to fetch comments from the db based on the listing_id
 async function getComments(listingID) {
   const [result] = await sequelize.query(
-    'SELECT * FROM fujiji_comments WHERE listing_id = ?;',
+    `SELECT fc.*, fu.name 
+      FROM fujiji_comments fc LEFT JOIN fujiji_user fu
+        ON fc.user_id = fu.user_id
+      WHERE listing_id = ? 
+      ORDER BY fc.creation_date DESC;`,
     {
       replacements: [listingID],
       type: Sequelize.SELECT,

--- a/fujiji-server/src/repositories/comment.js
+++ b/fujiji-server/src/repositories/comment.js
@@ -2,6 +2,7 @@ const { Sequelize } = require('sequelize');
 const { logDebug } = require('../utils/logging');
 const sequelize = require('./db');
 
+// PURPOSE: used to insert a new comment to the db
 async function createComment(userID, listingID, comment, isAuthor) {
   const [result] = await sequelize.query(
     `INSERT INTO fujiji_comments
@@ -18,6 +19,7 @@ async function createComment(userID, listingID, comment, isAuthor) {
   return result[0];
 }
 
+// PURPOSE: used to fetch comments from the db based on the listing_id
 async function getComments(listingID) {
   const [result] = await sequelize.query(
     'SELECT * FROM fujiji_comments WHERE listing_id = ?;',

--- a/fujiji-server/src/routes/comment.js
+++ b/fujiji-server/src/routes/comment.js
@@ -7,7 +7,10 @@ const {
 
 const router = express.Router();
 
+// POST /comment/listing_id, user must be authenticated
 router.post('/:listing_id', authentication, postComment);
+
+// GET /comment/listing_id
 router.get('/:listing_id', getListingComments);
 
 module.exports = router;

--- a/fujiji-server/src/routes/comment.js
+++ b/fujiji-server/src/routes/comment.js
@@ -2,10 +2,12 @@ const express = require('express');
 const authentication = require('../middleware/authentication');
 const {
   postComment,
+  getListingComments,
 } = require('../controllers/comment');
 
 const router = express.Router();
 
 router.post('/:listing_id', authentication, postComment);
+router.get('/:listing_id', getListingComments);
 
 module.exports = router;


### PR DESCRIPTION
# Description

Endpoint
- Implemented GET /comment/listing_id
- Doesn't require authentication
- Return 404 Not Found if the listing_id does not exist in the DB
- Return an empty list if there is no comment

Misc:
- Added `modified_date` column in the fujiji_comments table using the new migration script

Closes #103 