### PR TITLE
feat/#105: Implement PUT comment endpoint

### DIFF
--- a/fujiji-server/src/controllers/comment.js
+++ b/fujiji-server/src/controllers/comment.js
@@ -1,10 +1,18 @@
 const {
   createComment,
   getComments,
+  getCommentById,
+  updateCommentById,
+  highlightsCommentById,
 } = require('../repositories/comment');
 const { getListingById } = require('../repositories/listing');
 
-const { APIError, ListingNotFound } = require('../errors');
+const {
+  APIError,
+  ListingNotFound,
+  EmptyCommentError,
+  CommentNotFoundError,
+} = require('../errors');
 
 // PURPOSE: implement the post comment endpoint
 async function postComment(req, res, next) {
@@ -14,7 +22,7 @@ async function postComment(req, res, next) {
   const userID = parseInt(id, 10);
 
   if (!comment) {
-    return res.status(400).json({ error: "'comment' field can not be empty" });
+    return next(new EmptyCommentError());
   }
 
   const listing = await getListingById(parseInt(listingID, 10));
@@ -62,4 +70,56 @@ async function getListingComments(req, res, next) {
   }
 }
 
-module.exports = { postComment, getListingComments };
+// PURPOSE: implement the put comment endpoint
+async function editComment(req, res, next) {
+  const { comment, isHighlighted } = req.body;
+  const { comment_id: commentID } = req.params;
+  const { id } = req.locals.userData;
+  const userID = parseInt(id, 10);
+  const intCommentId = parseInt(commentID, 10);
+
+  const existingComment = await getCommentById(intCommentId);
+
+  if (!existingComment) {
+    return next(
+      new CommentNotFoundError(`comment with id:${commentID} is not found`),
+    );
+  }
+
+  const listingID = existingComment.listing_id;
+  const listing = await getListingById(parseInt(listingID, 10));
+
+  if (!listing) {
+    return next(
+      new ListingNotFound(`listing with id:${listingID} is not found`),
+    );
+  }
+
+  const isCommenter = userID === parseInt(existingComment.user_id, 10) ? 1 : 0;
+
+  const isAuthor = userID === parseInt(listing.user_id, 10) ? 1 : 0;
+
+  try {
+    if (isCommenter) {
+      if (!comment) {
+        return next(new EmptyCommentError());
+      }
+
+      if (comment != existingComment.comment) {
+        await updateCommentById(intCommentId, comment);
+      }
+    }
+    if (isAuthor) {
+      if (isHighlighted != existingComment.isHighlighted) {
+        await highlightsCommentById(intCommentId, isHighlighted);
+      }
+    }
+
+    const updatedComment = await getCommentById(intCommentId);
+    return res.status(200).json({ updatedComment });
+  } catch (err) {
+    return next(new APIError(err, 500));
+  }
+}
+
+module.exports = { postComment, getListingComments, editComment };

--- a/fujiji-server/src/errors/comment/commentNotFound.js
+++ b/fujiji-server/src/errors/comment/commentNotFound.js
@@ -1,0 +1,9 @@
+const APIError = require('../api');
+
+class CommentNotFoundError extends APIError {
+  constructor(message) {
+    super(message || 'No comment with such id is found.', 404);
+  }
+}
+
+module.exports = CommentNotFoundError;

--- a/fujiji-server/src/errors/comment/emptyComment.js
+++ b/fujiji-server/src/errors/comment/emptyComment.js
@@ -1,0 +1,9 @@
+const APIError = require('../api');
+
+class EmptyCommentError extends APIError {
+  constructor(message) {
+    super(message || "'comment' field can not be empty", 400);
+  }
+}
+
+module.exports = EmptyCommentError;

--- a/fujiji-server/src/errors/comment/index.js
+++ b/fujiji-server/src/errors/comment/index.js
@@ -1,0 +1,7 @@
+const EmptyCommentError = require('./emptyComment');
+const CommentNotFoundError = require('./commentNotFound');
+
+module.exports = {
+  EmptyCommentError,
+  CommentNotFoundError,
+};

--- a/fujiji-server/src/errors/index.js
+++ b/fujiji-server/src/errors/index.js
@@ -1,3 +1,5 @@
 const APIError = require('./api');
 
-module.exports = { APIError, ...require('./auth'), ...require('./listing') };
+module.exports = {
+  APIError, ...require('./auth'), ...require('./listing'), ...require('./comment'),
+};

--- a/fujiji-server/src/repositories/comment.js
+++ b/fujiji-server/src/repositories/comment.js
@@ -40,3 +40,60 @@ module.exports = {
   createComment,
   getComments,
 };
+
+// PURPOSE: used to fetch a comment from the db based on its id
+async function getCommentById(commentID) {
+  const [result] = await sequelize.query(
+    'SELECT * FROM fujiji_comments WHERE comment_id = ?;',
+    {
+      replacements: [commentID],
+      type: Sequelize.SELECT,
+    },
+  );
+  logDebug('DEBUG-getCommentById', result);
+  return result[0];
+}
+
+module.exports = {
+  createComment,
+  getComments,
+  getCommentById,
+};
+
+// PURPOSE: used to update a comment from the db based on its id
+async function updateCommentById(commentID, comment) {
+  const [result] = await sequelize.query(
+    `UPDATE fujiji_comments 
+      SET comment = ?, modified_date = getutcdate() 
+      WHERE comment_id = ?;`,
+    {
+      replacements: [comment, commentID],
+      type: Sequelize.UPDATE,
+    },
+  );
+  logDebug('DEBUG-updateCommentById', result);
+  return result;
+}
+
+// PURPOSE: used to highlight a comment from the db based on its id
+async function highlightsCommentById(commentID, isHighlighted) {
+  const [result] = await sequelize.query(
+    `UPDATE fujiji_comments 
+      SET isHighlighted = ?
+      WHERE comment_id = ?;`,
+    {
+      replacements: [isHighlighted, commentID],
+      type: Sequelize.UPDATE,
+    },
+  );
+  logDebug('DEBUG-highlightsCommentById', result);
+  return result;
+}
+
+module.exports = {
+  createComment,
+  getComments,
+  getCommentById,
+  updateCommentById,
+  highlightsCommentById,
+};

--- a/fujiji-server/src/routes/comment.js
+++ b/fujiji-server/src/routes/comment.js
@@ -3,6 +3,7 @@ const authentication = require('../middleware/authentication');
 const {
   postComment,
   getListingComments,
+  editComment,
 } = require('../controllers/comment');
 
 const router = express.Router();
@@ -12,5 +13,8 @@ router.post('/:listing_id', authentication, postComment);
 
 // GET /comment/listing_id
 router.get('/:listing_id', getListingComments);
+
+// PUT /comment/comment_id
+router.put('/:comment_id', authentication, editComment);
 
 module.exports = router;


### PR DESCRIPTION
# Description

- Implemented PUT /comment/comment_id
- Requires authentication
- Return 404 Not Found if the comment_id does not exist in the DB
- Returns the updated comment object when successful
- Only the listing owner can highlight a comment and only the commenter can edit their comment
- `modified_date` only gets updated when a comment is updated, not when it's being highlighted
- Needs `comment` and `isHighlighted` in the payload (if the user is not the listing owner, the `isHighlighted` column in the db won't get updated)

Closes #105