### PR TITLE
feat/#108: Create comment form component

### DIFF
--- a/fujiji-client/src/components/CommentForm/CommentForm.jsx
+++ b/fujiji-client/src/components/CommentForm/CommentForm.jsx
@@ -1,0 +1,95 @@
+import PropTypes from 'prop-types';
+import { useState } from 'react';
+import {
+  Box,
+  Button,
+  FormControl,
+  FormErrorMessage,
+  Textarea,
+  Flex,
+  Text,
+  useToast,
+} from '@chakra-ui/react';
+import { useSession } from '../../context/session';
+
+export default function CommentForm({
+  listingID,
+  userName,
+  onSubmit,
+}) {
+  const [comment, setComment] = useState('');
+  const [errorMessage, setErrorMessage] = useState('');
+
+  const { authToken } = useSession();
+  const toast = useToast();
+
+  return (
+    <Flex>
+      <FormControl isInvalid={errorMessage !== ''}>
+        <Text mb="1" fontSize="sm">
+          Comment as
+          {' '}
+          <Text d="inline" fontWeight="semibold" color="teal">
+            {userName}
+          </Text>
+        </Text>
+        <Textarea
+          mt="1"
+          aria-label="comment-input"
+          value={comment}
+          onChange={(e) => {
+            setErrorMessage('');
+            setComment(e.target.value);
+          }}
+          placeholder="Write your comment"
+          isInvalid={errorMessage !== ''}
+        />
+        <FormErrorMessage>{errorMessage}</FormErrorMessage>
+        <Box mt="2">
+          <Button
+            aria-label="submit-comment-button"
+            size="sm"
+            float="right"
+            colorScheme="teal"
+            variant="solid"
+            onClick={async () => {
+              if (!comment) {
+                setErrorMessage("comment can't be empty");
+                return;
+              }
+
+              const payload = {
+                comment,
+                listingID,
+                authToken,
+              };
+
+              const response = await onSubmit(payload);
+
+              if (response.error) {
+                setErrorMessage('Oops! Something went wrong...');
+              } else {
+                setComment('');
+                toast({
+                  id: 'submit-comment-success-toast',
+                  title: 'Successfully submit a comment!',
+                  status: 'success',
+                  duration: 9000,
+                  isClosable: true,
+                });
+              }
+            }}
+          >
+            Comment
+          </Button>
+        </Box>
+      </FormControl>
+    </Flex>
+  );
+}
+
+CommentForm.propTypes = {
+  listingID: PropTypes.number,
+  userName: PropTypes.string,
+  onSubmit: PropTypes.func,
+};

--- a/fujiji-client/src/components/CommentForm/CommentForm.spec.jsx
+++ b/fujiji-client/src/components/CommentForm/CommentForm.spec.jsx
@@ -1,0 +1,76 @@
+import { render, fireEvent, act } from '@testing-library/react';
+
+import CommentForm from './CommentForm';
+
+const mockDefaultProps = {
+  listingID: 12,
+  userName: 'Jane',
+  onSubmit: jest.fn(),
+};
+
+describe('CommentForm', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should render properly', () => {
+    const { getByText } = render(<CommentForm {...mockDefaultProps} />);
+    expect(getByText(mockDefaultProps.userName)).toBeInTheDocument();
+  });
+
+  it('should render input changes in the textarea', () => {
+    const { getByLabelText, getByText } = render(
+      <CommentForm {...mockDefaultProps} />,
+    );
+
+    fireEvent.change(getByLabelText('comment-input'), {
+      target: { value: 'new comment' },
+    });
+
+    expect(getByText('new comment')).toBeInTheDocument();
+  });
+
+  it('should render error message when submitting empty comment', () => {
+    const { getByLabelText, getByText } = render(
+      <CommentForm {...mockDefaultProps} />,
+    );
+
+    fireEvent.click(getByLabelText('submit-comment-button'));
+    expect(getByText("comment can't be empty")).toBeInTheDocument();
+  });
+
+  it('should submit the POST form when comment is valid', async () => {
+    mockDefaultProps.onSubmit.mockResolvedValueOnce({ status: 200 });
+
+    const { getByLabelText } = render(<CommentForm {...mockDefaultProps} />);
+
+    fireEvent.change(getByLabelText('comment-input'), {
+      target: { value: 'new comment' },
+    });
+
+    await act(async () => {
+      fireEvent.click(getByLabelText('submit-comment-button'));
+    });
+
+    expect(getByLabelText('comment-input')).toHaveValue('');
+    expect(mockDefaultProps.onSubmit).toHaveBeenCalledTimes(1);
+  });
+
+  it('should show error message when submission failed', async () => {
+    mockDefaultProps.onSubmit.mockResolvedValueOnce({ error: 'failed' });
+
+    const { getByLabelText, getByText } = render(<CommentForm {...mockDefaultProps} />);
+
+    fireEvent.change(getByLabelText('comment-input'), {
+      target: { value: 'new comment' },
+    });
+
+    await act(async () => {
+      fireEvent.click(getByLabelText('submit-comment-button'));
+    });
+
+    expect(getByLabelText('comment-input')).toHaveValue('new comment');
+    expect(getByText('Oops! Something went wrong...')).toBeInTheDocument();
+    expect(mockDefaultProps.onSubmit).toHaveBeenCalledTimes(1);
+  });
+});

--- a/fujiji-client/src/components/CommentForm/CommentForm.stories.jsx
+++ b/fujiji-client/src/components/CommentForm/CommentForm.stories.jsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import CommentForm from './CommentForm';
+
+export default {
+  title: 'CommentForm',
+  component: CommentForm,
+};
+
+function Template({ ...args }) {
+  return <CommentForm {...args} />;
+}
+
+export const Default = Template.bind({});
+Default.args = {
+  userName: 'John Doe',
+  onSubmit: () => ({ status: 200 }),
+};
+
+export const ApiError = Template.bind({});
+ApiError.args = {
+  userName: 'John Doe',
+  onSubmit: () => ({ error: {} }),
+};

--- a/fujiji-client/src/server/api/postComment.js
+++ b/fujiji-client/src/server/api/postComment.js
@@ -1,0 +1,39 @@
+import axios from 'axios';
+import config from '../../../config';
+import getQueryString from '../../utils/getQueryString';
+
+export default async function postComment({
+  listingID,
+  comment,
+  authToken,
+}) {
+  const queryString = getQueryString({
+    comment,
+  });
+
+  try {
+    const result = await axios.post(
+      `${config.FUJIJI_API_URL}/comment/${listingID}`,
+      queryString,
+      {
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded',
+          Authorization: `Bearer ${authToken}`,
+        },
+      },
+    );
+    return result;
+  } catch (error) {
+    if (error.response) {
+      const { data, status } = error.response;
+      return {
+        error: data.error,
+        status,
+      };
+    }
+    return {
+      error: 'Something went wrong... Check if Fujiji API is running',
+      status: 500,
+    };
+  }
+}


### PR DESCRIPTION
# Description

- Users can't submit empty comment, can only submit non-empty comments

Closes #108 

# Demo

When a user's typing a comment:
<img width="581" alt="typingComment" src="https://user-images.githubusercontent.com/57550160/161401302-a97082b6-06fc-4289-b6fa-4b7c041a84f8.png">

If the submission is success:
<img width="584" alt="successComment" src="https://user-images.githubusercontent.com/57550160/161401319-b32f846b-6459-42cc-85bb-840c689a27c4.png">

If the submission failed:
<img width="592" alt="failedComment" src="https://user-images.githubusercontent.com/57550160/161401328-24acf28e-49f4-4a01-91c8-0668ae428aca.png">

User can't submit empty comment:
<img width="589" alt="can'tbeemptyComment" src="https://user-images.githubusercontent.com/57550160/161401335-3e7df12e-9338-4644-ae74-530e6a7552e1.png">
