### PR TITLE
Update azure-pipelines-server.yml

### DIFF
--- a/azure-pipelines-server.yml
+++ b/azure-pipelines-server.yml
@@ -35,8 +35,8 @@ steps:
 
   - task: Docker@2
     inputs:
-      containerRegistry: "fujijicontainer"
-      repository: "Azure Container Registry"
+      containerRegistry: "fujijiServerConnection"
+      repository: "jishanarora1997/fujijiServer"
       command: "buildAndPush"
       Dockerfile: "**/Dockerfile.prod"
       tags: $(Build.BuildNumber)


### PR DESCRIPTION
We will now be using the dockerhub to store our docker images and therefore the pipeline will push the images to dockehub which will be further used in prod.

No significant changes in here except the service connection, majority of the changes in the portal side.