### PR TITLE
feat/#145: implement boost indicator

### DIFF
--- a/fujiji-client/src/components/AdListingCard/AdListingCard.jsx
+++ b/fujiji-client/src/components/AdListingCard/AdListingCard.jsx
@@ -5,6 +5,7 @@ import {
 import { MdLocationOn } from 'react-icons/md';
 import { BsCalendar } from 'react-icons/bs';
 import { format, isValid, parse } from 'date-fns';
+import { TriangleUpIcon } from '@chakra-ui/icons';
 import ConditionBadge from '../ConditionBadge/ConditionBadge';
 
 function ListingInfoBox({ children }) {
@@ -23,6 +24,7 @@ function ListingInfoBox({ children }) {
   );
 }
 export default function AdListingCard({
+  isBoosted = false,
   imageUrl,
   imageAlt,
   title,
@@ -46,7 +48,8 @@ export default function AdListingCard({
     <Box
       as="button"
       w="xs"
-      borderWidth="1px"
+      borderWidth={isBoosted ? '2px' : '1px'}
+      borderColor={isBoosted ? 'teal.400' : ''}
       rounded="lg"
       onClick={onClick}
       _hover={{ boxShadow: 'lg' }}
@@ -99,7 +102,17 @@ export default function AdListingCard({
           alignItems="center"
           justifyContent="space-between"
         >
-          <ConditionBadge condition={condition} />
+          <Box>
+            {isBoosted && (
+              <TriangleUpIcon
+                data-testid="TEST_BOOST_ICON"
+                color="teal"
+                mr="3"
+                fontSize="20"
+              />
+            )}
+            <ConditionBadge condition={condition} />
+          </Box>
           <Box
             textAlign="right"
             fontSize="lg"
@@ -121,6 +134,7 @@ ListingInfoBox.propTypes = {
 };
 
 AdListingCard.propTypes = {
+  isBoosted: PropTypes.bool,
   imageUrl: PropTypes.string,
   imageAlt: PropTypes.string,
   title: PropTypes.string,

--- a/fujiji-client/src/components/AdListingCard/AdListingCard.spec.jsx
+++ b/fujiji-client/src/components/AdListingCard/AdListingCard.spec.jsx
@@ -37,4 +37,17 @@ describe('AdListingCard', () => {
 
     expect(queryByText('21 Feb 2022')).toBeFalsy();
   });
+
+  it('should not render boosted badge', () => {
+    const mockBoostedListingProps = {
+      ...mockAdListing[0],
+      isBoosted: true,
+    };
+
+    const { getByTestId } = render(
+      <AdListingCard {...mockBoostedListingProps} />,
+    );
+
+    expect(getByTestId('TEST_BOOST_ICON')).toBeInTheDocument();
+  });
 });

--- a/fujiji-client/src/components/AdListingCard/AdListingCard.stories.jsx
+++ b/fujiji-client/src/components/AdListingCard/AdListingCard.stories.jsx
@@ -40,3 +40,9 @@ export const TruncatedTitle = Template.bind({});
 TruncatedTitle.args = {
   ...mockAdListing[3],
 };
+
+export const BoostedListing = Template.bind({});
+BoostedListing.args = {
+  ...mockAdListing[0],
+  isBoosted: true,
+};

--- a/fujiji-client/src/components/Listing/Listing.jsx
+++ b/fujiji-client/src/components/Listing/Listing.jsx
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types';
 import {
   Box, Button, Flex, Text, Image, Icon, Link,
 } from '@chakra-ui/react';
+import { TriangleUpIcon } from '@chakra-ui/icons';
 import { MdLocationOn } from 'react-icons/md';
 import { BsCalendar } from 'react-icons/bs';
 import { BiCategory } from 'react-icons/bi';
@@ -37,6 +38,7 @@ function ListingInfoBox({ icon, infoField, infoContent }) {
 
 export default function Listing({
   isSeller = false,
+  boostDayLeft,
   listingID,
   category,
   condition,
@@ -89,6 +91,17 @@ export default function Listing({
         <Text fontSize="3xl" fontWeight="bold">
           {title}
         </Text>
+
+        {isSeller && boostDayLeft > 0 && (
+          <Text my="2" color="grey">
+            <TriangleUpIcon mr="2" color="yellow.400" fontSize="20" />
+            This listing is boosted.
+            {' '}
+            {boostDayLeft}
+            {' '}
+            days remaining.
+          </Text>
+        )}
 
         <Box mt="2">
           <ConditionBadge condition={condition} />
@@ -168,6 +181,7 @@ ListingInfoBox.propTypes = {
 
 Listing.propTypes = {
   isSeller: PropTypes.bool,
+  boostDayLeft: PropTypes.number,
   listingID: PropTypes.number,
   imageUrl: PropTypes.string,
   title: PropTypes.string,

--- a/fujiji-client/src/components/Listing/Listing.spec.jsx
+++ b/fujiji-client/src/components/Listing/Listing.spec.jsx
@@ -5,7 +5,9 @@ import mockAdListing from '../../__mocks__/mockAdListing';
 
 describe('Listing', () => {
   it('should render properly', () => {
-    const { getByText, getByLabelText, queryByLabelText } = render(<Listing {...mockAdListing[0]} />);
+    const { getByText, getByLabelText, queryByLabelText } = render(
+      <Listing {...mockAdListing[0]} />,
+    );
     expect(getByText(mockAdListing[0].title)).toBeInTheDocument();
     expect(getByText(mockAdListing[0].description)).toBeInTheDocument();
     expect(getByText('new')).toBeInTheDocument();
@@ -15,7 +17,9 @@ describe('Listing', () => {
   });
 
   it("should render edit button if this listing is seller's", () => {
-    const { getByText, getByLabelText, queryByLabelText } = render(<Listing {...mockAdListing[0]} isSeller />);
+    const { getByText, getByLabelText, queryByLabelText } = render(
+      <Listing {...mockAdListing[0]} isSeller />,
+    );
     expect(getByText(mockAdListing[0].title)).toBeInTheDocument();
     expect(getByText(mockAdListing[0].description)).toBeInTheDocument();
     expect(getByText('new')).toBeInTheDocument();
@@ -28,9 +32,7 @@ describe('Listing', () => {
     const mockPropsWithoutDescription = {
       ...mockAdListing[2],
     };
-    const { getByText } = render(
-      <Listing {...mockPropsWithoutDescription} />,
-    );
+    const { getByText } = render(<Listing {...mockPropsWithoutDescription} />);
     expect(getByText(mockPropsWithoutDescription.title)).toBeInTheDocument();
     expect(
       getByText('No description provided by the seller.'),
@@ -65,5 +67,19 @@ describe('Listing', () => {
 
     fireEvent.click(getByLabelText('contact-seller-button'), { bubbles: true });
     expect(mockOnContactClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('should show boosted days remaining', () => {
+    const mockBoostedListingProps = {
+      ...mockAdListing[0],
+      boostDayLeft: 3,
+      isSeller: true,
+    };
+
+    const { getByText } = render(<Listing {...mockBoostedListingProps} />);
+
+    expect(
+      getByText('This listing is boosted. 3 days remaining.'),
+    ).toBeInTheDocument();
   });
 });

--- a/fujiji-client/src/components/Listing/Listing.stories.jsx
+++ b/fujiji-client/src/components/Listing/Listing.stories.jsx
@@ -41,3 +41,10 @@ SellerListing.args = {
   isSeller: true,
   ...mockAdListing[0],
 };
+
+export const BoostedListing = Template.bind({});
+BoostedListing.args = {
+  isSeller: true,
+  boostDayLeft: 3,
+  ...mockAdListing[0],
+};

--- a/fujiji-client/src/pages/search/index.jsx
+++ b/fujiji-client/src/pages/search/index.jsx
@@ -26,10 +26,14 @@ import { SettingsIcon, Search2Icon } from '@chakra-ui/icons';
 import { BsCurrencyDollar } from 'react-icons/bs';
 import { useRouter } from 'next/router';
 import PropTypes from 'prop-types';
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useCallback } from 'react';
 import { AdListingCard } from '../../components';
 import { searchListings } from '../../server/api';
-import { provinces, furnitureCategories, conditions } from '../../utils/fujijiConfig';
+import {
+  provinces,
+  furnitureCategories,
+  conditions,
+} from '../../utils/fujijiConfig';
 
 function SearchPage({
   condition = '',
@@ -51,7 +55,7 @@ function SearchPage({
 
   const { isOpen, onOpen, onClose } = useDisclosure();
 
-  const getSearchListings = async () => {
+  const getSearchListings = useCallback(async () => {
     const payload = {
       title: searchText,
       condition: listingCondition,
@@ -62,7 +66,15 @@ function SearchPage({
       endPrice: maxListingPrice,
     };
     return searchListings(payload);
-  };
+  }, [
+    searchText,
+    listingCondition,
+    listingCategory,
+    listingCity,
+    listingProvince,
+    minListingPrice,
+    maxListingPrice,
+  ]);
 
   const clearFilters = () => {
     setSearchText('');
@@ -89,7 +101,7 @@ function SearchPage({
     }
 
     fetchData();
-  });
+  }, [getSearchListings]);
 
   let renderListings;
 
@@ -147,7 +159,6 @@ function SearchPage({
   };
 
   return (
-
     <Center px="1" py="6" flexDir="column">
       <Modal isOpen={isOpen} onClose={onClose}>
         <ModalOverlay />
@@ -157,7 +168,10 @@ function SearchPage({
           <ModalBody>
             <FormControl>
               <Box flex="1">
-                <FormLabel htmlFor="listingCdondition" id="listing-condition-label">
+                <FormLabel
+                  htmlFor="listingCdondition"
+                  id="listing-condition-label"
+                >
                   Condition
                 </FormLabel>
                 <Select
@@ -174,7 +188,10 @@ function SearchPage({
                 </Select>
               </Box>
               <Box flex="1" mt={4}>
-                <FormLabel htmlFor="listingCategory" id="listing-category-label">
+                <FormLabel
+                  htmlFor="listingCategory"
+                  id="listing-category-label"
+                >
                   Category
                 </FormLabel>
                 <Select
@@ -204,7 +221,10 @@ function SearchPage({
                 />
               </Box>
               <Box mt={4}>
-                <FormLabel htmlFor="listingProvince" id="listing-province-label">
+                <FormLabel
+                  htmlFor="listingProvince"
+                  id="listing-province-label"
+                >
                   Province
                 </FormLabel>
                 <Select
@@ -262,7 +282,9 @@ function SearchPage({
           </ModalBody>
 
           <ModalFooter>
-            <Button variant="ghost" mr={3} onClick={clearFilters}>clear</Button>
+            <Button variant="ghost" mr={3} onClick={clearFilters}>
+              clear
+            </Button>
             <Button colorScheme="teal" onClick={handleOnSubmit}>
               Apply
             </Button>


### PR DESCRIPTION
# Description

Implement boost indicator on `AdListingCard` and `Listing` components

Fixes bug on some browser where `useEffect` called multiple times by setting the dependencies that will trigger the hook.

Closes #145 

# Demo