### PR TITLE
feat/#150: Create boost package selection component

### DIFF
--- a/fujiji-client/src/components/BoostPackageSelection/BoostPackageSelection.jsx
+++ b/fujiji-client/src/components/BoostPackageSelection/BoostPackageSelection.jsx
@@ -1,0 +1,98 @@
+import PropTypes from 'prop-types';
+import {
+  Button, Box, Flex, Text,
+} from '@chakra-ui/react';
+
+import { useState } from 'react';
+import { ArrowForwardIcon } from '@chakra-ui/icons';
+
+const packages = [
+  { id: 0, name: '3 Days Boost', price: 5 },
+  { id: 1, name: '7 Days Boost', price: 10 },
+  { id: 2, name: '30 Days Boost', price: 30 },
+];
+
+function PackageButton({
+  isSelected,
+  packageId,
+  packageName,
+  packagePrice,
+  onClick,
+}) {
+  return (
+    <Button
+      d="flex"
+      flexDir="row"
+      justifyContent="space-between"
+      mb="3"
+      p="6"
+      id={`package-${packageId}-button`}
+      aria-label={`select ${packageName} package button`}
+      colorScheme={isSelected ? 'teal' : 'gray'}
+      variant={isSelected ? 'solid' : 'outline'}
+      onClick={onClick}
+    >
+      <Flex>{packageName}</Flex>
+      <Flex>
+        $
+        {packagePrice}
+      </Flex>
+    </Button>
+  );
+}
+
+export default function BoostPackageSelection({ onContinue }) {
+  const [selectedId, setSelectedId] = useState(0);
+
+  return (
+    <Box
+      maxW="450px"
+      borderWidth="1px"
+      borderColor="grey.100"
+      borderRadius="base"
+      p="6"
+    >
+      <Text fontSize="xl" mb="4">
+        Select your package:
+      </Text>
+      <Flex flexDir="column">
+        {packages.map((pckg) => (
+          <PackageButton
+            isSelected={selectedId === pckg.id}
+            packageId={pckg.id}
+            packageName={pckg.name}
+            packagePrice={pckg.price}
+            onClick={() => {
+              setSelectedId(pckg.id);
+            }}
+          />
+        ))}
+      </Flex>
+      <Flex mt="5">
+        <Button
+          colorScheme="blue"
+          rightIcon={<ArrowForwardIcon />}
+          ml="auto"
+          aria-label="continue-to-payment-buttons"
+          onClick={() => {
+            onContinue(selectedId);
+          }}
+        >
+          Continue
+        </Button>
+      </Flex>
+    </Box>
+  );
+}
+
+BoostPackageSelection.propTypes = {
+  onContinue: PropTypes.func,
+};
+
+PackageButton.propTypes = {
+  isSelected: PropTypes.bool,
+  packageId: PropTypes.number,
+  packageName: PropTypes.string,
+  packagePrice: PropTypes.number,
+  onClick: PropTypes.func,
+};

--- a/fujiji-client/src/components/BoostPackageSelection/BoostPackageSelection.spec.jsx
+++ b/fujiji-client/src/components/BoostPackageSelection/BoostPackageSelection.spec.jsx
@@ -1,0 +1,36 @@
+import { render, fireEvent } from '@testing-library/react';
+
+import BoostPackageSelection from './BoostPackageSelection';
+
+const packages = [
+  { id: 0, name: '3 Days Boost', price: 5 },
+  { id: 1, name: '7 Days Boost', price: 10 },
+  { id: 2, name: '30 Days Boost', price: 30 },
+];
+
+describe('BoostPackageSelection', () => {
+  it('should render component successfully', () => {
+    const { getByText } = render(<BoostPackageSelection />);
+    expect(getByText('3 Days Boost')).toBeInTheDocument();
+    expect(getByText('7 Days Boost')).toBeInTheDocument();
+    expect(getByText('30 Days Boost')).toBeInTheDocument();
+  });
+
+  it('should successfully call onContinue callback with selected ID', () => {
+    const mockOnContinue = jest.fn();
+    const { getByLabelText } = render(
+      <BoostPackageSelection onContinue={mockOnContinue} />,
+    );
+
+    fireEvent.click(
+      getByLabelText(`select ${packages[1].name} package button`),
+      { bubbles: true },
+    );
+
+    fireEvent.click(getByLabelText('continue-to-payment-buttons'), {
+      bubbles: true,
+    });
+
+    expect(mockOnContinue).toHaveBeenCalledWith(packages[1].id);
+  });
+});

--- a/fujiji-client/src/components/BoostPackageSelection/BoostPackageSelection.stories.jsx
+++ b/fujiji-client/src/components/BoostPackageSelection/BoostPackageSelection.stories.jsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import BoostPackageSelection from './BoostPackageSelection';
+
+export default {
+  title: 'BoostPackageSelection',
+  component: BoostPackageSelection,
+};
+
+function Template({ ...args }) {
+  return <BoostPackageSelection {...args} />;
+}
+
+export const Default = Template.bind({});

--- a/fujiji-client/src/components/Listing/Listing.jsx
+++ b/fujiji-client/src/components/Listing/Listing.jsx
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import {
   Box, Button, Flex, Text, Image, Icon, Link,
 } from '@chakra-ui/react';
-import { TriangleUpIcon } from '@chakra-ui/icons';
+import { StarIcon, TriangleUpIcon } from '@chakra-ui/icons';
 import { MdLocationOn } from 'react-icons/md';
 import { BsCalendar } from 'react-icons/bs';
 import { BiCategory } from 'react-icons/bi';
@@ -145,13 +145,29 @@ export default function Listing({
             {formattedPrice}
           </Box>
           {isSeller && (
-            <Button
-              aria-label="edit-listing-button"
-              colorScheme="teal"
-              onClick={onEditClick}
-            >
-              Edit
-            </Button>
+            <Box>
+              <Button
+                aria-label="edit-listing-button"
+                colorScheme="teal"
+                onClick={onEditClick}
+              >
+                Edit
+              </Button>
+              {!boostDayLeft && (
+                <Button
+                  leftIcon={<StarIcon />}
+                  ml="3"
+                  variant="outline"
+                  aria-label="boost-listing-button"
+                  colorScheme="yellow"
+                  onClick={() => {
+                    // TODO: implement this
+                  }}
+                >
+                  Boost
+                </Button>
+              )}
+            </Box>
           )}
           {!isSeller && (
             <Link

--- a/fujiji-client/src/components/index.js
+++ b/fujiji-client/src/components/index.js
@@ -11,3 +11,4 @@ export { default as withSession } from './withSession/withSession';
 export { default as EditProfile } from './EditProfile/EditProfile';
 export { default as Comment } from './Comment/Comment';
 export { default as CommentForm } from './CommentForm/CommentForm';
+export { default as BoostPackageSelection } from './BoostPackageSelection/BoostPackageSelection';


### PR DESCRIPTION
# Description

Create a component for selecting Boost package.

Added Boost button in `Listing` component.

The functionality will be implemented when POST endpoint and payment's UI are ready.

Closes #151 

# Demo

<img width="735" alt="Screen Shot 2022-04-13 at 1 53 21 AM" src="https://user-images.githubusercontent.com/36686154/163118169-2101dcfc-534a-4985-85ac-833d9dd2ef1b.png">

<img width="990" alt="Screen Shot 2022-04-13 at 1 53 34 AM" src="https://user-images.githubusercontent.com/36686154/163118164-6d2f7ae3-b049-4982-9449-af8a4dee2ad0.png">

