### PR TITLE
Feat/#160 Implemented comment's reply endpoint

### DIFF
--- a/fujiji-server/__test__/dbSetup.js
+++ b/fujiji-server/__test__/dbSetup.js
@@ -60,8 +60,10 @@ async function seedTestDB() {
 }
 
 async function tearDownDB() {
-  await sequelize.query('DELETE FROM fujiji_user');
+  await sequelize.query('DELETE FROM fujiji_comments');
+  await sequelize.query('DELETE FROM fujiji_boost');
   await sequelize.query('DELETE FROM fujiji_listing');
+  await sequelize.query('DELETE FROM fujiji_user');
 }
 
 module.exports = {

--- a/fujiji-server/migration-scripts/add_comment_reply.sql
+++ b/fujiji-server/migration-scripts/add_comment_reply.sql
@@ -1,0 +1,1 @@
+ALTER TABLE fujiji_comments ADD reply text;

--- a/fujiji-server/migration-scripts/example.sql
+++ b/fujiji-server/migration-scripts/example.sql
@@ -9,6 +9,9 @@ SELECT *
 FROM fujiji_listing;
 
 SELECT *
+FROM fujiji_comments;
+
+SELECT *
 FROM fujiji_boost_package;
 
 SELECT *

--- a/fujiji-server/migration-scripts/up.sql
+++ b/fujiji-server/migration-scripts/up.sql
@@ -61,6 +61,7 @@ CREATE TABLE fujiji_comments
     comment text NOT NULL,
     isHighlighted int NOT NULL,
     isAuthor int NOT NULL,
+    reply text,
     creation_date DATETIME NOT NULL,
     modified_date DATETIME,
     CONSTRAINT PK_fujiji_comments PRIMARY KEY NONCLUSTERED (comment_id),

--- a/fujiji-server/src/repositories/comment.js
+++ b/fujiji-server/src/repositories/comment.js
@@ -75,6 +75,21 @@ async function updateCommentById(commentID, comment) {
   return result;
 }
 
+// PURPOSE: used to update a comment's reply based on its id
+async function replyCommentById(commentID, reply) {
+  const [result] = await sequelize.query(
+    `UPDATE fujiji_comments 
+      SET reply = ? 
+      WHERE comment_id = ?;`,
+    {
+      replacements: [reply, commentID],
+      type: Sequelize.UPDATE,
+    },
+  );
+  logDebug('DEBUG-replyCommentById', result);
+  return result;
+}
+
 // PURPOSE: used to highlight a comment from the db based on its id
 async function highlightsCommentById(commentID, isHighlighted) {
   const [result] = await sequelize.query(
@@ -107,6 +122,23 @@ async function deleteCommentById(commentId) {
   }
 }
 
+// PURPOSE: used to delete a comment from the db based on its id
+async function deleteCommentReplyById(commentId) {
+  try {
+    const result = await sequelize.query(
+      'UPDATE fujiji_comments SET reply = NULL WHERE comment_id = ?;',
+      {
+        replacements: [commentId],
+        type: Sequelize.UPDATE,
+      },
+    );
+    logDebug('DEBUG-deleteCommentReplyById', result);
+    return result;
+  } catch (err) {
+    return err;
+  }
+}
+
 module.exports = {
   createComment,
   getComments,
@@ -114,4 +146,6 @@ module.exports = {
   updateCommentById,
   highlightsCommentById,
   deleteCommentById,
+  replyCommentById,
+  deleteCommentReplyById,
 };

--- a/fujiji-server/src/routes/comment.js
+++ b/fujiji-server/src/routes/comment.js
@@ -5,6 +5,8 @@ const {
   getListingComments,
   editComment,
   deleteComment,
+  replyComment,
+  deleteCommentReply,
 } = require('../controllers/comment');
 
 const router = express.Router();
@@ -20,5 +22,11 @@ router.put('/:comment_id', authentication, editComment);
 
 // DEL /comment/comment_id
 router.delete('/:comment_id', authentication, deleteComment);
+
+// to reply to a comment specified by their comment_id
+router.put('/reply/:comment_id', authentication, replyComment);
+
+// to delete a comment's reply
+router.put('/delete-reply/:comment_id', authentication, deleteCommentReply);
 
 module.exports = router;


### PR DESCRIPTION
# Description

- Added a new `reply` column in the `fujiji_comments` table
- Use `PUT /comment/reply/:comment_id` to reply or edit the reply to a comment with `comment_id`, expecting `reply` in the request's body
- Use `PUT /comment/delete-reply/:comment_id` to delete the reply to a comment with `comment_id`, not expecting anything in the request's body
- Only the listing owner/author can reply to a comment
- Require authentication

Closes #160