### PR TITLE
feat/#161: create single nested comment reply

### DIFF
--- a/fujiji-client/src/components/Comment/Comment.stories.jsx
+++ b/fujiji-client/src/components/Comment/Comment.stories.jsx
@@ -34,14 +34,14 @@ Seller.args = {
   commentDate: '2022-02-21',
 };
 
-export const Highlightable = Template.bind({});
-Highlightable.args = {
+export const SellerOptions = Template.bind({});
+SellerOptions.args = {
   commentID: 2,
   posterName: 'John Doe',
   comment:
     'Lorem Ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.',
   isSeller: false,
-  isHighlightable: true,
+  showSellerOptions: true,
   isEditable: false,
   isHighlighted: false,
   commentDate: '2022-02-21',
@@ -96,6 +96,41 @@ Modified.args = {
   modifiedDate: '2022-02-21',
 };
 
+function ReplyStory({ ...args }) {
+  const reply = <Comment {...args.reply} />;
+  return <Comment {...args.comment} reply={reply} />;
+}
+
+export const Reply = ReplyStory.bind({});
+Reply.args = {
+  comment: {
+    commentID: 6,
+    posterName: 'John Doe',
+    comment:
+      'Lorem Ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.',
+    reply:
+      'Lorem Ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.',
+    isSeller: false,
+    showSellerOptions: true,
+    isEditable: false,
+    isHighlighted: false,
+    commentDate: '2022-02-21',
+    modifiedDate: undefined,
+  },
+  reply: {
+    commentID: 6,
+    posterName: 'The Seller',
+    comment:
+      'Lorem Ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.',
+    isSeller: true,
+    showSellerOptions: false,
+    isEditable: true,
+    isHighlighted: false,
+    commentDate: '2022-02-21',
+    modifiedDate: undefined,
+  },
+};
+
 function CommentsChainStory({ ...args }) {
   return (
     <div>
@@ -116,7 +151,7 @@ CommentsChain.args = [
     comment:
       'Lorem Ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.',
     isSeller: true,
-    isHighlightable: true,
+    showSellerOptions: true,
     isEditable: true,
     isHighlighted: true,
     commentDate: '2022-02-21',

--- a/fujiji-client/src/components/CommentForm/CommentForm.jsx
+++ b/fujiji-client/src/components/CommentForm/CommentForm.jsx
@@ -10,15 +10,19 @@ import {
   Text,
   useToast,
 } from '@chakra-ui/react';
+import { useRouter } from 'next/router';
 import { useSession } from '../../context/session';
 
 export default function CommentForm({
   listingID,
+  commentID,
   userName,
   onSubmit,
+  isReply,
 }) {
   const [comment, setComment] = useState('');
   const [errorMessage, setErrorMessage] = useState('');
+  const router = useRouter();
 
   const { authToken } = useSession();
   const toast = useToast();
@@ -27,15 +31,14 @@ export default function CommentForm({
     <Flex>
       <FormControl isInvalid={errorMessage !== ''}>
         <Text mb="1" fontSize="md">
-          Comment as
-          {' '}
+          {isReply ? 'Reply as seller' : 'Comment as '}
           <Text d="inline" fontWeight="semibold" color="teal">
             {userName}
           </Text>
         </Text>
         <Textarea
           mt="1"
-          aria-label="comment-input"
+          aria-label={isReply ? 'reply-input' : 'comment-input'}
           value={comment}
           onChange={(e) => {
             setErrorMessage('');
@@ -47,7 +50,9 @@ export default function CommentForm({
         <FormErrorMessage>{errorMessage}</FormErrorMessage>
         <Box mt="2">
           <Button
-            aria-label="submit-comment-button"
+            aria-label={
+              isReply ? 'submit-reply-button' : 'submit-comment-button'
+            }
             size="sm"
             float="right"
             colorScheme="teal"
@@ -58,11 +63,13 @@ export default function CommentForm({
                 return;
               }
 
-              const payload = {
-                comment,
-                listingID,
-                authToken,
-              };
+              const payload = isReply
+                ? { commentID, reply: comment, authToken }
+                : {
+                  comment,
+                  listingID,
+                  authToken,
+                };
 
               const response = await onSubmit(payload);
 
@@ -77,10 +84,11 @@ export default function CommentForm({
                   duration: 9000,
                   isClosable: true,
                 });
+                router.reload(window.location.pathname);
               }
             }}
           >
-            Comment
+            {isReply ? 'Reply' : 'Comment'}
           </Button>
         </Box>
       </FormControl>
@@ -90,6 +98,8 @@ export default function CommentForm({
 
 CommentForm.propTypes = {
   listingID: PropTypes.number,
+  commentID: PropTypes.number,
   userName: PropTypes.string,
   onSubmit: PropTypes.func,
+  isReply: PropTypes.bool,
 };

--- a/fujiji-client/src/components/CommentForm/CommentForm.stories.jsx
+++ b/fujiji-client/src/components/CommentForm/CommentForm.stories.jsx
@@ -16,6 +16,13 @@ Default.args = {
   onSubmit: () => ({ status: 200 }),
 };
 
+export const Reply = Template.bind({});
+Reply.args = {
+  userName: '',
+  isReply: true,
+  onSubmit: () => ({ status: 200 }),
+};
+
 export const ApiError = Template.bind({});
 ApiError.args = {
   userName: 'John Doe',

--- a/fujiji-client/src/pages/listing/[id].jsx
+++ b/fujiji-client/src/pages/listing/[id].jsx
@@ -33,25 +33,42 @@ function ListingComments({
   comments,
   userID = undefined,
   sellerID = undefined,
+  sellerName = '',
 }) {
   if (!comments || comments.length === 0 || comments.error) {
     return null;
   }
 
-  const isHighlightable = parseInt(userID, 10) === parseInt(sellerID, 10);
+  const showSellerOptions = parseInt(userID, 10) === parseInt(sellerID, 10);
 
   return comments.map((comment) => {
     const commentProps = {
       ...comment,
-      isHighlightable,
+      showSellerOptions,
       isEditable: userID
         ? parseInt(userID, 10) === parseInt(comment.userID, 10)
         : false,
     };
 
+    const replyProps = {
+      commentID: comment.commentID,
+      listingID: comment.listingID,
+      posterName: sellerName,
+      comment: comment.reply,
+      showSellerOptions: false,
+      isEditable: showSellerOptions,
+      isHighlighted: false,
+      isSeller: true,
+      isReply: true,
+    };
+
+    const commentReply = comment.reply ? (
+      <Comment {...replyProps} />
+    ) : undefined;
+
     return (
       <Box key={`comment-${comment.commentID}`}>
-        <Comment {...commentProps} />
+        <Comment {...commentProps} reply={commentReply} />
       </Box>
     );
   });
@@ -115,6 +132,7 @@ function IndividualListingPage({ listingData, commentsData }) {
             comments: listingComments,
             userID: session.userData?.userID,
             sellerID: listingData.userID,
+            sellerName: listingData.sellerName,
           })}
         </Box>
       </Flex>
@@ -142,6 +160,7 @@ IndividualListingPage.propTypes = {
   listingData: PropTypes.shape({
     userID: PropTypes.number,
     listingID: PropTypes.number,
+    sellerName: PropTypes.string,
     title: PropTypes.string,
     condition: PropTypes.string,
     category: PropTypes.string,
@@ -160,8 +179,9 @@ IndividualListingPage.propTypes = {
       userID: PropTypes.number,
       posterName: PropTypes.string,
       comment: PropTypes.string,
-      isHighlighted: PropTypes.bool,
+      reply: PropTypes.elementType,
       isSeller: PropTypes.bool,
+      isHighlighted: PropTypes.bool,
       commentDate: PropTypes.string,
       modifiedDate: PropTypes.string,
     }),
@@ -183,4 +203,5 @@ ListingComments.propTypes = {
   ),
   userID: PropTypes.number,
   sellerID: PropTypes.number,
+  sellerName: PropTypes.string,
 };

--- a/fujiji-client/src/server/api/deleteCommentReplyById.js
+++ b/fujiji-client/src/server/api/deleteCommentReplyById.js
@@ -1,0 +1,30 @@
+import axios from 'axios';
+import getConfig from 'next/config';
+
+export default async function deleteCommentReplyById(commentId, authToken) {
+  try {
+    const { publicRuntimeConfig } = getConfig();
+    const result = await axios.put(
+      `${publicRuntimeConfig.FUJIJI_API_URL}/comment/delete-reply/${commentId}`,
+      {},
+      {
+        headers: {
+          Authorization: `Bearer ${authToken}`,
+        },
+      },
+    );
+    return result;
+  } catch (error) {
+    if (error.response) {
+      const { data, status } = error.response;
+      return {
+        error: data.error,
+        status,
+      };
+    }
+    return {
+      error: 'Something went wrong... Check if Fujiji API is running',
+      status: 500,
+    };
+  }
+}

--- a/fujiji-client/src/server/api/getCommentsByListingId.js
+++ b/fujiji-client/src/server/api/getCommentsByListingId.js
@@ -34,6 +34,7 @@ export default async function getCommentsByListingId(listingID) {
         isSeller: commentObj.isAuthor === 1,
         commentDate: formattedDate,
         modifiedDate: formattedModifiedDate,
+        reply: commentObj.reply,
       };
     });
   } catch (error) {

--- a/fujiji-client/src/server/api/getListingById.js
+++ b/fujiji-client/src/server/api/getListingById.js
@@ -8,9 +8,15 @@ export default async function getListingById(listingId) {
       `${publicRuntimeConfig.FUJIJI_API_URL}/listing/${listingId}`,
     );
     const { listing } = result.data;
+
+    const { data } = await axios.get(
+      `${publicRuntimeConfig.FUJIJI_API_URL}/user/${listing.user_id}`,
+    );
+
     return {
       userID: parseInt(listing.user_id, 10),
       listingID: parseInt(listing.listing_id, 10),
+      sellerName: data.user.name,
       title: listing.title,
       condition: listing.condition,
       category: listing.category,

--- a/fujiji-client/src/server/api/index.js
+++ b/fujiji-client/src/server/api/index.js
@@ -14,3 +14,5 @@ export { default as getAllListings } from './getAllListings';
 export { default as getCommentsByListingId } from './getCommentsByListingId';
 export { default as uploadImage } from './uploadImage';
 export { default as searchListings } from './searchListings';
+export { default as replyComment } from './replyComment';
+export { default as deleteCommentReplyById } from './deleteCommentReplyById';

--- a/fujiji-client/src/server/api/replyComment.js
+++ b/fujiji-client/src/server/api/replyComment.js
@@ -1,0 +1,36 @@
+import axios from 'axios';
+import getConfig from 'next/config';
+import getQueryString from '../../utils/getQueryString';
+
+export default async function replyComment({ commentID, reply, authToken }) {
+  const queryString = getQueryString({
+    reply,
+  });
+
+  try {
+    const { publicRuntimeConfig } = getConfig();
+    const result = await axios.put(
+      `${publicRuntimeConfig.FUJIJI_API_URL}/comment/reply/${commentID}`,
+      queryString,
+      {
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded',
+          Authorization: `Bearer ${authToken}`,
+        },
+      },
+    );
+    return result;
+  } catch (error) {
+    if (error.response) {
+      const { data, status } = error.response;
+      return {
+        error: data.error,
+        status,
+      };
+    }
+    return {
+      error: 'Something went wrong... Check if Fujiji API is running',
+      status: 500,
+    };
+  }
+}


### PR DESCRIPTION
# Description

Create single nested comment for. Only seller can reply to a comment.

Added a `reply` prop to `Comment` component. That accept another `Comment` component and will be rendered as a reply.

Closes #161

# Demo

https://user-images.githubusercontent.com/36686154/163642904-f7ec642d-c23b-4961-a750-66e509f0562c.mov


