### PR TITLE
Update GET listing endpoints to include boost score

### DIFF
--- a/fujiji-server/__test__/controllers/boost.test.js
+++ b/fujiji-server/__test__/controllers/boost.test.js
@@ -47,7 +47,6 @@ describe('Test /boost endpoints', () => {
         .post(`/boost/${postListingRes.body.listingId}`)
         .query({ packageID: 1 })
         .set('Authorization', `Bearer ${token}`);
-
       expect(postBoostRes.statusCode).toEqual(200);
     });
 
@@ -82,7 +81,6 @@ describe('Test /boost endpoints', () => {
         .post(`/boost/${postListingRes.body.listingId}`)
         .query({ packageID: 4 })
         .set('Authorization', `Bearer ${token}`);
-
       expect(postBoostRes.statusCode).toEqual(404);
     });
   });

--- a/fujiji-server/__test__/controllers/listing.test.js
+++ b/fujiji-server/__test__/controllers/listing.test.js
@@ -170,8 +170,13 @@ describe('Test /listing endpoints', () => {
         .post('/listing')
         .set('Authorization', `Bearer ${token}`)
         .send(mockReqBody);
+      await request(app)
+        .post(`/boost/${postRes.body.listingId}`)
+        .query({ packageID: 1 })
+        .set('Authorization', `Bearer ${token}`);
       const res = await request(app).get(`/listing/${postRes.body.listingId}`);
       expect(res.statusCode).toEqual(200);
+      expect(res.body.listing.score).toEqual(150);
     });
 
     it('returns 404 with non-existent listingID', async () => {

--- a/fujiji-server/package-lock.json
+++ b/fujiji-server/package-lock.json
@@ -3338,9 +3338,9 @@
       }
     },
     "node_modules/artillery-plugin-publish-metrics/node_modules/async": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
-      "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
+      "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
       "dev": true,
       "dependencies": {
         "lodash": "^4.17.14"
@@ -10569,9 +10569,9 @@
       }
     },
     "node_modules/moment": {
-      "version": "2.29.1",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
-      "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==",
+      "version": "2.29.2",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.2.tgz",
+      "integrity": "sha512-UgzG4rvxYpN15jgCmVJwac49h9ly9NurikMWGPdVxm8GZD6XjkKPxDTjQQ43gtGgnV3X0cAyWDdP2Wexoquifg==",
       "engines": {
         "node": "*"
       }
@@ -19186,9 +19186,9 @@
       },
       "dependencies": {
         "async": {
-          "version": "2.6.3",
-          "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
-          "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+          "version": "2.6.4",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
+          "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
           "dev": true,
           "requires": {
             "lodash": "^4.17.14"
@@ -24593,9 +24593,9 @@
       }
     },
     "moment": {
-      "version": "2.29.1",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
-      "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ=="
+      "version": "2.29.2",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.2.tgz",
+      "integrity": "sha512-UgzG4rvxYpN15jgCmVJwac49h9ly9NurikMWGPdVxm8GZD6XjkKPxDTjQQ43gtGgnV3X0cAyWDdP2Wexoquifg=="
     },
     "moment-timezone": {
       "version": "0.5.34",

--- a/fujiji-server/src/repositories/boost.js
+++ b/fujiji-server/src/repositories/boost.js
@@ -19,6 +19,22 @@ async function createBoost(listingID, packageid, score) {
   return result[0];
 }
 
+async function getBoostByListingId(listingID) {
+  try {
+    const [boost] = await sequelize.query(
+      'SELECT * FROM fujiji_boost WHERE listing_id = ?',
+      {
+        replacements: [listingID],
+        type: Sequelize.SELECT,
+      },
+    );
+    logDebug('DEBUG-getBoostByListingId', boost);
+    return boost[0];
+  } catch (err) {
+    return err;
+  }
+}
+
 module.exports = {
-  createBoost,
+  createBoost, getBoostByListingId,
 };


### PR DESCRIPTION
Included Boost data score in these endpoints' response body:
-getAllListings: GET /listing
-getByListingId: GET /listing/:id
-getAllListingsBySearch: GET /listing/search
If the listing is not boosted then score: -1
The code works for now but ineffiecient as It gives an eslint error for using await function inside loop.

Closes #153