### PR TITLE
feat/#167: show boost indicator on pages

### DIFF
--- a/fujiji-client/src/pages/listing/[id].jsx
+++ b/fujiji-client/src/pages/listing/[id].jsx
@@ -95,6 +95,7 @@ function IndividualListingPage({ listingData, commentsData }) {
         ? false
         : parseInt(listingData.userID, 10)
           === parseInt(session.userData?.userID, 10),
+    boostDayLeft: listingData.score > 0 ? listingData.score / 5 : 0,
   };
 
   const handleSubmitComment = async (payload) => {
@@ -171,6 +172,7 @@ IndividualListingPage.propTypes = {
     description: PropTypes.string,
     creationDate: PropTypes.string,
     contactEmail: PropTypes.string,
+    score: PropTypes.number,
     error: PropTypes.string,
   }),
   commentsData: PropTypes.arrayOf(

--- a/fujiji-client/src/pages/user/[userId]/listings.jsx
+++ b/fujiji-client/src/pages/user/[userId]/listings.jsx
@@ -98,5 +98,6 @@ UserListingsPage.propTypes = {
     description: PropTypes.string,
     creationDate: PropTypes.string,
     error: PropTypes.string,
+    isBoosted: PropTypes.bool,
   }),
 };

--- a/fujiji-client/src/server/api/getListingById.js
+++ b/fujiji-client/src/server/api/getListingById.js
@@ -27,6 +27,7 @@ export default async function getListingById(listingId) {
       description: listing.description,
       postingDate: listing.creation_date,
       contactEmail: listing.contact_email,
+      score: parseInt(listing.score, 10),
     };
   } catch (error) {
     if (error.response) {

--- a/fujiji-client/src/server/api/getListingByUserId.js
+++ b/fujiji-client/src/server/api/getListingByUserId.js
@@ -33,6 +33,7 @@ export default async function getListingByUserId(userId, authToken) {
         price: listing.price,
         description: listing.description,
         postingDate: formattedDate,
+        isBoosted: parseInt(listing.score, 10) > 0,
       };
     });
   } catch (error) {

--- a/fujiji-server/package.json
+++ b/fujiji-server/package.json
@@ -54,7 +54,8 @@
   "jest": {
     "testEnvironment": "node",
     "coveragePathIgnorePatterns": [
-      "/node_modules/"
+      "/node_modules/",
+      "/src/errors/"
     ],
     "collectCoverageFrom": [
       "src/**/*.js"

--- a/fujiji-server/src/controllers/user.js
+++ b/fujiji-server/src/controllers/user.js
@@ -1,6 +1,7 @@
 const bcrypt = require('bcrypt');
 const jwt = require('jsonwebtoken');
 const { getUserByID, getUserListingsByID, updateUser } = require('../repositories/user');
+const { getBoostByListingId } = require('../repositories/boost');
 const APIError = require('../errors/api');
 const UserNotFoundError = require('../errors/user/userNotFound');
 const UserListingsNotFoundError = require('../errors/user/userListingsNotFound');
@@ -52,6 +53,17 @@ async function getUserListings(req, res, next) {
       next(new UserListingsNotFoundError());
       return;
     }
+
+    for (let index = 0; index < userListings.length; index += 1) {
+      // eslint-disable-next-line no-await-in-loop
+      const boost = await getBoostByListingId(userListings[index].listing_id);
+      if (!boost) {
+        userListings[index].score = -1;
+      } else {
+        userListings[index].score = boost.score;
+      }
+    }
+
     res.status(200).json({ userListings });
   } catch (err) {
     next(new APIError());


### PR DESCRIPTION
# Description

Show the boost indicator on `/search` and `/user/listings` pages

Closes #167 

# Demo
<img width="1424" alt="Screen Shot 2022-04-19 at 5 08 40 PM" src="https://user-images.githubusercontent.com/36686154/164109892-4d411f33-5c1c-4871-a631-307023955f48.png">
<img width="1424" alt="Screen Shot 2022-04-19 at 5 08 33 PM" src="https://user-images.githubusercontent.com/36686154/164109894-47463ff9-909b-45a4-999a-ebc86880aa5b.png">

